### PR TITLE
Backport 0.13 - hide processes groups on processes index

### DIFF
--- a/decidim-regulations/app/controllers/decidim/participatory_processes/participatory_processes_controller.rb
+++ b/decidim-regulations/app/controllers/decidim/participatory_processes/participatory_processes_controller.rb
@@ -46,7 +46,7 @@ module Decidim
       end
 
       def collection
-        @collection ||= (participatory_processes.to_a + participatory_process_groups).flatten
+        @collection ||= participatory_processes
       end
 
       def filtered_participatory_processes(filter = default_filter)


### PR DESCRIPTION
Modify the `collection` method so that it doesn't return the process groups to the index view of participatory processes.