### PR TITLE
[WIP] Migrate customizations to decidim standards

### DIFF
--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -1,0 +1,12 @@
+ca:
+  area_type:
+    departments:
+      name: Departament
+      plural: Departaments
+  scope_parent:
+    themes:
+      name: Temes
+  scope_type:
+    regulations:
+      name: Participació en normativa
+      plural: Participació en normatives

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1,0 +1,12 @@
+es:
+  area_type:
+    departments:
+      name: Departamento
+      plural: Departamentos
+  scope_parent:
+    themes:
+      name: Temas
+  scope_type:
+    regulations:
+      name: Participación en normativa
+      plural: Participación en normativas

--- a/config/locales/oc.yml
+++ b/config/locales/oc.yml
@@ -1,0 +1,12 @@
+ca:
+  area_type:
+    departments:
+      name: Departament
+      plural: Departaments
+  scope_parent:
+    themes:
+      name: Temes
+  scope_type:
+    regulations:
+      name: Participació normativa
+      plural: Participació normatives

--- a/db/migrate/20190319161354_add_area_to_participatory_process.rb
+++ b/db/migrate/20190319161354_add_area_to_participatory_process.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddAreaToParticipatoryProcess < ActiveRecord::Migration[5.2]
+  def change
+    add_reference :decidim_participatory_processes, :decidim_area, index: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_02_11_105658) do
+ActiveRecord::Schema.define(version: 2019_03_19_161354) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "ltree"
@@ -841,6 +841,8 @@ ActiveRecord::Schema.define(version: 2019_02_11_105658) do
     t.integer "decidim_type_id"
     t.string "reference"
     t.boolean "private_space", default: false
+    t.bigint "decidim_area_id"
+    t.index ["decidim_area_id"], name: "index_decidim_participatory_processes_on_decidim_area_id"
     t.index ["decidim_organization_id", "slug"], name: "index_unique_process_slug_and_organization", unique: true
     t.index ["decidim_organization_id"], name: "index_decidim_processes_on_decidim_organization_id"
   end

--- a/decidim-process-extended/app/commands/decidim/participatory_processes/admin/copy_participatory_process.rb
+++ b/decidim-process-extended/app/commands/decidim/participatory_processes/admin/copy_participatory_process.rb
@@ -64,9 +64,10 @@ module Decidim
             # Participa added attributes
             show_home: @participatory_process.show_home,
             email: @participatory_process.email,
-            decidim_department_id: @participatory_process.decidim_department_id,
-            decidim_type_id: @participatory_process.decidim_type_id,
-            decidim_theme_id: @participatory_process.decidim_theme_id
+            area: @participatory_process.area,
+            # decidim_department_id: @participatory_process.decidim_department_id,
+            # decidim_type_id: @participatory_process.decidim_type_id,
+            # decidim_theme_id: @participatory_process.decidim_theme_id
           )
         end
 

--- a/decidim-process-extended/app/commands/decidim/participatory_processes/admin/create_participatory_process.rb
+++ b/decidim-process-extended/app/commands/decidim/participatory_processes/admin/create_participatory_process.rb
@@ -65,9 +65,10 @@ module Decidim
             # Participa added attributes
             email: form.email.downcase,
             show_home: form.show_home,
-            decidim_department_id: form.department_id,
-            decidim_type_id: form.type_id,
-            decidim_theme_id: form.theme_id
+            area: form.area,
+            # decidim_department_id: form.department_id,
+            # decidim_type_id: form.type_id,
+            # decidim_theme_id: form.theme_id
           )
 
           return process unless process.valid?

--- a/decidim-process-extended/app/commands/decidim/participatory_processes/admin/update_participatory_process.rb
+++ b/decidim-process-extended/app/commands/decidim/participatory_processes/admin/update_participatory_process.rb
@@ -80,9 +80,10 @@ module Decidim
             # Participa added attributes
             email: form.email,
             show_home: form.show_home,
-            decidim_department_id: form.department_id,
-            decidim_type_id: form.type_id,
-            decidim_theme_id: form.theme_id
+            area: form.area
+            # decidim_department_id: form.department_id,
+            # decidim_type_id: form.type_id,
+            # decidim_theme_id: form.theme_id
           }
         end
       end

--- a/decidim-process-extended/app/form/decidim/participatory_processes/admin/participatory_process_form.rb
+++ b/decidim-process-extended/app/form/decidim/participatory_processes/admin/participatory_process_form.rb
@@ -30,6 +30,7 @@ module Decidim
         attribute :promoted, Boolean
         attribute :scopes_enabled, Boolean
         attribute :scope_id, Integer
+        attribute :area_id, Integer
         attribute :hero_image
         attribute :remove_hero_image
         attribute :banner_image
@@ -55,6 +56,8 @@ module Decidim
         validates :hero_image, file_size: { less_than_or_equal_to: ->(_record) { Decidim.maximum_attachment_size } }, file_content_type: { allow: ["image/jpeg", "image/png"] }
         validates :banner_image, file_size: { less_than_or_equal_to: ->(_record) { Decidim.maximum_attachment_size } }, file_content_type: { allow: ["image/jpeg", "image/png"] }
 
+        validates :area, presence: true, if: proc { |object| object.area_id.present? }
+
         # after_save :example_function
         def map_model(model)
           self.scope_id = model.decidim_scope_id
@@ -68,6 +71,10 @@ module Decidim
 
         def scope
           @scope ||= current_organization.scopes.where(id: scope_id).first
+        end
+
+        def area
+          @area ||= current_organization.areas.find_by(id: area_id)
         end
 
         def participatory_process_group

--- a/decidim-process-extended/app/views/decidim/participatory_processes/admin/participatory_processes/_form.html.erb
+++ b/decidim-process-extended/app/views/decidim/participatory_processes/admin/participatory_processes/_form.html.erb
@@ -78,6 +78,10 @@
     </div>
 
     <div class="row column">
+      <%= form.select :area_id, option_groups_from_collection_for_select(current_organization.area_types, :areas, :translated_name, :id, :translated_name, current_participatory_process.try(:decidim_area_id)), include_blank: t(".select_an_area") %>
+    </div>
+
+    <div class="row column">
       <%= form.translated :text_field, :participatory_scope %>
     </div>
 
@@ -91,31 +95,31 @@
           <%= form.select :participatory_process_group_id, process_groups_for_select, prompt: I18n.t("decidim.participatory_processes.participatory_process_groups.none") %>
         <% end %>
       </div>
-      <div class="columns xlarge-6">
-        <% if departments_for_select %>
-          <%= form.select :department_id, departments_for_select, include_blank: I18n.t("decidim.themes.none") %>
-        <% end %>
-      </div>
+      <!-- <div class="columns xlarge-6">
+        <%# if departments_for_select %>
+          <%#= form.select :department_id, departments_for_select, include_blank: I18n.t("decidim.themes.none") %>
+        <%# end %>
+      </div> -->
     </div>
 
-    <div class="row">
+    <!-- <div class="row">
       <div class="columns xlarge-6">
-        <% if themes_for_select %>
-          <%= form.select :theme_id, themes_for_select, include_blank: I18n.t("decidim.themes.none") %>
-        <% end %>
+        <%# if themes_for_select %>
+          <%#= form.select :theme_id, themes_for_select, include_blank: I18n.t("decidim.themes.none") %>
+        <%# end %>
       </div>
 
       <div class="columns xlarge-6">
-        <% if types_for_select %>
-          <%= form.select :type_id, types_for_select, include_blank: I18n.t("decidim.themes.none") %>
-        <% end %>
+        <%# if types_for_select %>
+          <%#= form.select :type_id, types_for_select, include_blank: I18n.t("decidim.themes.none") %>
+        <%# end %>
       </div>
-    </div>
+    </div> -->
 
     <div class="row column">
       <%= form.check_box :private_space %>
     </div>
-    
+
     <div class="row column">
       <%= form.check_box :show_statistics %>
     </div>

--- a/decidim-process-extended/config/locales/ca.yml
+++ b/decidim-process-extended/config/locales/ca.yml
@@ -9,6 +9,7 @@ ca:
         participatory_processes:
           form:
             appear_home: Sortir al home (imatge)
+            select_an_area: Selecciona una àrea
     projects:
       filters:
         category: Eixos de debat

--- a/decidim-process-extended/config/locales/es.yml
+++ b/decidim-process-extended/config/locales/es.yml
@@ -9,6 +9,7 @@ es:
         participatory_processes:
           form:
             appear_home: Aparecer en home (imagen)
+            select_an_area: Selecciona una area
     projects:
       filters:
         category: Ejes de debate

--- a/decidim-process-extended/config/locales/oc.yml
+++ b/decidim-process-extended/config/locales/oc.yml
@@ -9,6 +9,7 @@ oc:
         participatory_processes:
           form:
             appear_home: Sortir al home (imatge)
+            select_an_area: Selecciona una àrea
       pages:
         home:
           highlighted_processes:

--- a/decidim-regulations/app/controllers/decidim/participatory_processes/participatory_processes_controller.rb
+++ b/decidim-regulations/app/controllers/decidim/participatory_processes/participatory_processes_controller.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+module Decidim
+  module ParticipatoryProcesses
+    # A controller that holds the logic to show ParticipatoryProcesses in a
+    # public layout.
+    class ParticipatoryProcessesController < Decidim::ParticipatoryProcesses::ApplicationController
+      include ParticipatorySpaceContext
+      participatory_space_layout only: :show
+
+      helper Decidim::AttachmentsHelper
+      helper Decidim::IconHelper
+      helper Decidim::WidgetUrlsHelper
+      helper Decidim::SanitizeHelper
+      helper Decidim::ResourceReferenceHelper
+
+      helper ParticipatoryProcessHelper
+
+      helper_method :collection, :promoted_participatory_processes, :participatory_processes, :stats, :filter, :categories, :has_debats, :is_subcategory
+      helper_method :process_count_by_filter
+
+      def index
+        redirect_to "/404" if published_processes.none?
+
+        enforce_permission_to :list, :process
+        enforce_permission_to :list, :process_group
+      end
+
+      def show
+        check_current_user_can_visit_space
+      end
+
+      private
+
+      def organization_participatory_processes
+        @organization_participatory_processes ||= OrganizationParticipatoryProcesses.new(current_organization).query
+      end
+
+      def current_participatory_space
+        return unless params["slug"]
+
+        @current_participatory_space ||= organization_participatory_processes.where(slug: params["slug"]).or(
+          organization_participatory_processes.where(id: params["slug"])
+        ).first!
+      end
+
+      def published_processes
+        @published_processes ||= OrganizationPublishedParticipatoryProcesses.new(current_organization, current_user)
+      end
+
+      # This is customized because GENCAT don't Processes Groups on Index Page
+      def collection
+        @collection ||= participatory_processes
+      end
+      # This is customized because GENCAT don't Processes Groups on Index Page
+
+      def filtered_participatory_processes(filter_name = filter)
+        OrganizationPrioritizedParticipatoryProcesses.new(current_organization, filter_name, current_user)
+      end
+
+      def participatory_processes
+        @participatory_processes ||= filtered_participatory_processes(filter)
+      end
+
+      def promoted_participatory_processes
+        @promoted_processes ||= filtered_participatory_processes | PromotedParticipatoryProcesses.new
+      end
+
+      def filtered_participatory_process_groups(filter_name = filter)
+        OrganizationPrioritizedParticipatoryProcessGroups.new(current_organization, filter_name)
+      end
+
+      def participatory_process_groups
+        @process_groups ||= filtered_participatory_process_groups(filter)
+      end
+
+      def stats
+        @stats ||= ParticipatoryProcessStatsPresenter.new(participatory_process: current_participatory_space)
+      end
+
+      def filter
+        @filter = params[:filter] || default_filter
+      end
+
+      def default_filter
+        return "active" if process_count_by_filter["active"].positive?
+        return "upcoming" if process_count_by_filter["upcoming"].positive?
+        return "past" if process_count_by_filter["past"].positive?
+        "active"
+      end
+
+      # This is customized because GENCAT don't Processes Groups on Index Page
+      def process_count_by_filter
+        return @process_count_by_filter if @process_count_by_filter
+
+        @process_count_by_filter = %w(active upcoming past).inject({}) do |collection_by_filter, filter_name|
+          processes = filtered_participatory_processes(filter_name)
+          collection_by_filter.merge(filter_name.to_s => processes.count)
+        end
+        @process_count_by_filter["all"] = @process_count_by_filter.values.sum
+        @process_count_by_filter
+      end
+      # This is customized because GENCAT don't Processes Groups on Index Page
+    end
+  end
+end

--- a/lib/tasks/move_custom_categorizations.rake
+++ b/lib/tasks/move_custom_categorizations.rake
@@ -4,7 +4,10 @@
 # because there are some custom categorizations to be removed
 # and leave it as Decidim standards
 namespace :move_custom_categorizations do
+<<<<<<< HEAD
 
+=======
+>>>>>>> bbd249451c0af74d1c9d8bfab2ebb7aa5d21dc72
   desc "Move Deparments to Areas"
   task departments_to_areas: [:environment] do
     class DecidimDepartment < ApplicationRecord
@@ -103,6 +106,17 @@ namespace :move_custom_categorizations do
         end
       end
     end
+<<<<<<< HEAD
+=======
+
+    # Move decidim_theme_id to Decidim::Scope Selector
+    # Decidim::ParticipatoryProcess.find_each do |process|
+    #   next unless process.decidim_theme_id.present?
+    #   scope = Decidim::Scope.find_by(code: DecidimTheme.find_by(id: process.decidim_theme_id).name[Decidim.default_locale.to_s].parameterize)
+    #   process.update_attributes(scopes_enabled: true, scope: scope)
+    #   puts "--- Process #{process.id} - Scope_id Updated #{scope.id}"
+    # end
+>>>>>>> bbd249451c0af74d1c9d8bfab2ebb7aa5d21dc72
   end
 
   desc "Assign scopes to ParticipatoryProcesses"
@@ -133,6 +147,7 @@ namespace :move_custom_categorizations do
     end
   end
 
+<<<<<<< HEAD
   desc "Assign Areas to ParticipatoryProcesses"
   task assign_areas_to_participatory_processes: [:environment] do
     class DecidimDepartment < ApplicationRecord
@@ -154,6 +169,8 @@ namespace :move_custom_categorizations do
   desc 'Move all custom categorizations and assign the new relations'
   task all: [:departments_to_areas, :types_to_scopes, :themes_to_scopes, :assign_scopes_to_participatory_processes, :assign_areas_to_participatory_processes ]
 
+=======
+>>>>>>> bbd249451c0af74d1c9d8bfab2ebb7aa5d21dc72
   def localized locales, key
     locales.inject({}) do |result, locale|
       I18n.locale = locale

--- a/lib/tasks/move_custom_categorizations.rake
+++ b/lib/tasks/move_custom_categorizations.rake
@@ -1,0 +1,153 @@
+# frozen_string_literal: true
+
+# Next tasks are necessary to be executed when deployed
+# because there are some custom categorizations to be removed
+# and leave it as Decidim standards
+namespace :move_custom_categorizations do
+  desc "Move Deparments to Areas"
+  task departments_to_areas: [:environment] do
+    class DecidimDepartment < ApplicationRecord
+      self.table_name = :decidim_departments
+    end
+
+    ActiveRecord::Base.transaction do
+      Decidim::Organization.find_each do |organization|
+        area_type = Decidim::AreaType.find_or_create_by(
+          name: localized(organization.available_locales, "area_type.departments.name"),
+          plural: localized(organization.available_locales, "area_type.departments.plural"),
+          organization: organization
+        )
+        puts "---AreaType created - #{area_type.id} - #{area_type.name}"
+
+        DecidimDepartment.where(decidim_organization_id: organization.id).each do |department|
+          area = Decidim::Area.find_or_create_by(
+            name: organization.available_locales.map { |l| [l, "#{department.name}"] }.to_h,
+            area_type: area_type,
+            organization: organization,
+          )
+          puts "---Area created - #{area.id} - #{area.name}"
+        end
+      end
+    end
+  end
+
+  desc "Move types to scopes"
+  task types_to_scopes: [:environment] do
+    class DecidimType < ApplicationRecord
+      self.table_name = :decidim_types
+    end
+
+    class DecidimTheme < ApplicationRecord
+      self.table_name = :decidim_themes
+    end
+
+    ActiveRecord::Base.transaction do
+      Decidim::Organization.find_each do |organization|
+        scope_type = Decidim::ScopeType.find_or_create_by(
+          name: localized(organization.available_locales, "scope_type.regulations.name"),
+          plural: localized(organization.available_locales, "scope_type.regulations.plural"),
+          organization: organization
+        )
+        puts "---ScopeType created - #{scope_type.id} - #{scope_type.name}"
+
+        DecidimType.where(decidim_organization_id: organization.id).each do |type|
+          scope = Decidim::Scope.find_or_create_by(
+            name: type.name,
+            code: type.name[organization.default_locale].parameterize,
+            scope_type: scope_type,
+            organization: organization,
+          )
+          puts "---Scope created - #{scope.id} - #{scope.name}"
+
+          DecidimTheme.where(decidim_organization_id: organization.id).each do |t|
+            scope_child = Decidim::Scope.find_or_create_by(
+              name: t.name,
+              code: "#{type.name[organization.default_locale].parameterize}-#{t.name[organization.default_locale].parameterize}",
+              organization: organization,
+              parent_id: scope.id,
+            )
+
+            puts "ScopeChild created #{scope_child.id} - #{scope_child.name}"
+          end
+        end
+      end
+    end
+  end
+
+  desc "Move themes to scopes"
+  task themes_to_scopes: [:environment] do
+    class DecidimTheme < ApplicationRecord
+      self.table_name = :decidim_themes
+    end
+
+    ActiveRecord::Base.transaction do
+      Decidim::Organization.find_each do |organization|
+        scope_parent = Decidim::Scope.find_or_create_by(
+          name: localized(organization.available_locales, "scope_parent.themes.name"),
+          code: "temes",
+          organization: organization
+        )
+
+        puts "+++++ ScopeParent Created #{scope_parent.id} - #{scope_parent.name}"
+
+        DecidimTheme.where(decidim_organization_id: organization.id).each do |t|
+          scope = Decidim::Scope.find_or_create_by(
+            name: t.name,
+            code: "tema-#{t.name[organization.default_locale].parameterize}",
+            organization: organization,
+            parent_id: scope_parent.id,
+          )
+
+          puts "ScopeChild created #{scope.id} - #{scope.name}"
+        end
+      end
+    end
+
+    # Move decidim_theme_id to Decidim::Scope Selector
+    # Decidim::ParticipatoryProcess.find_each do |process|
+    #   next unless process.decidim_theme_id.present?
+    #   scope = Decidim::Scope.find_by(code: DecidimTheme.find_by(id: process.decidim_theme_id).name[Decidim.default_locale.to_s].parameterize)
+    #   process.update_attributes(scopes_enabled: true, scope: scope)
+    #   puts "--- Process #{process.id} - Scope_id Updated #{scope.id}"
+    # end
+  end
+
+  desc "Assign scopes to ParticipatoryProcesses"
+  task assign_scopes_to_participatory_processes: [:environment] do
+    class DecidimType < ApplicationRecord
+      self.table_name = :decidim_types
+    end
+
+    class DecidimTheme < ApplicationRecord
+      self.table_name = :decidim_themes
+    end
+
+    Decidim::Organization.find_each do |organization|
+      Decidim::ParticipatoryProcess.where(organization: organization).find_each do |process|
+        if process.decidim_type_id.present?
+          next unless process.decidim_theme_id.present?
+          scope_parent = Decidim::Scope.find_by(code: "#{DecidimType.find_by(id: process.decidim_type_id).name[organization.default_locale].parameterize}")
+          scope_child = scope_parent.children.find_by(code: "#{scope_parent.code}-#{DecidimTheme.find_by(id: process.decidim_theme_id).name[organization.default_locale].parameterize}")
+          process.update_attributes(scopes_enabled: true, scope: scope_child)
+          puts "--- Process #{process.id} - Scope_id Updated #{scope_child.id}"
+        else
+          next unless process.decidim_theme_id.present?
+          scope = Decidim::Scope.find_by(code: "tema-#{DecidimTheme.find_by(id: process.decidim_theme_id).name[organization.default_locale].parameterize}")
+          process.update_attributes(scopes_enabled: true, scope: scope)
+          puts "--- Process #{process.id} - Scope_id Updated #{scope.id}"
+        end
+      end
+    end
+  end
+
+  def localized locales, key
+    locales.inject({}) do |result, locale|
+      I18n.locale = locale
+      text = I18n.t(key) do
+        yield
+      end
+
+      result.update(locale => text)
+    end.with_indifferent_access
+  end
+end


### PR DESCRIPTION
# Migrate customizations to decidim standards
This PR migrates de Customizations Themes, Departments and Type to standard elements that the Decidim platform already offers.

The issue consists in:

- [x] Add Areas to ParticipatoryProcess - #53 (Incloure a Decidim)
- [ ] A background process (Rake task) to migrate existing elements into new data structures.
    - [ ] Migrate Themes to Scope
    - [ ] Migrate Departments to Areas
    - [ ] Migrate Type to Scope: "Participació en normativa" will be the parent type and from here will hang both types that are currently as sub-scopes.
- [ ] Change Title of Areas to Departments - (gencat)
- [ ] Repeat existing filters by replacing them, if necessary (gencat)
- [ ] refer all existing associations. (gencat)
- [ ] Remove the FK (columns of BD) that point to the currently custom elements. (gencat)
  delete the tables and code related to Themes, Departments and Type. (gencat)
