### PR TITLE
[Backport] Rename `open_data` rake task in `config/schedule.rb`

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -11,3 +11,7 @@ end
 every 1.day, at: '2:00 am' do
   rake "decidim:metrics:all"
 end
+
+every :sunday, at: '11:59 pm' do
+  rake 'open_data:participatory_processes:publish_to_socrata'
+end


### PR DESCRIPTION
#### :tophat: What? Why?
Rename `open_data` rake task in `config/schedule.rb`

#### :pushpin: Related Issues
- Related to #70 
