### PR TITLE
Hide assemblies type filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Change Log
 **Upgrade notes:**
+- **Changed**: Hide `assembly_type` filter from `Assembly` index page as per request of Product Owner [#87](https://github.com/gencat/participa/pull/87)
 - **Added**: Admin Department Module [#84](https://github.com/gencat/participa/pull/84)
 - **Added**: Feat socrata open data. [#70](https://github.com/gencat/participa/pull/70)
 Review the [README#open-data](https://github.com/gencat/participa/blob/master/README.md#open-data) section to find out the required actions to perform

--- a/app/assets/stylesheets/decidim.scss
+++ b/app/assets/stylesheets/decidim.scss
@@ -541,14 +541,7 @@ h5 {
 }
 
 #assemblies-filter{
-  li{
-    color: #D04040 !important;
-    padding: 0.5em;
-  }
-
-  a{
-    text-decoration: none;
-  }
+  display: none;
 }
 
 #participatory-space-filters{


### PR DESCRIPTION
#### :tophat: What? Why?
- Hide assemblies type filter

#### :pushpin: Related Issues
- Related to #82 

### :camera: Screenshots (optional)
![hide_filter_assemblies_by_type](https://user-images.githubusercontent.com/40306853/57379257-deeb8e80-71a6-11e9-86e2-f3b3603f72fd.png)
