### PR TITLE
Prevent department_admin of being displayed as a component.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Change Log
 **Upgrade notes:**
+
+- **Changed**: Stop department_admin from being displayed as a component. [#88](https://github.com/gencat/participa/pull/88)
 - **Changed**: Hide `assembly_type` filter from `Assembly` index page as per request of Product Owner [#87](https://github.com/gencat/participa/pull/87)
 - **Added**: Admin Department Module [#84](https://github.com/gencat/participa/pull/84)
 - **Added**: Feat socrata open data. [#70](https://github.com/gencat/participa/pull/70)

--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,7 @@
 source "https://rubygems.org"
 
 ruby RUBY_VERSION
-# DECIDIM_VERSION = { git: 'https://github.com/gencat/decidim', tag: 'v0.18-dev-gencat-features' }.freeze
-DECIDIM_VERSION = { path: '../decidim-fork' }.freeze
+DECIDIM_VERSION = { git: 'https://github.com/gencat/decidim', tag: 'v0.18-dev-gencat-features' }.freeze
 
 gem "decidim", DECIDIM_VERSION
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,12 +1,13 @@
 source "https://rubygems.org"
 
 ruby RUBY_VERSION
-DECIDIM_VERSION = { git: 'https://github.com/gencat/decidim', tag: 'v0.18-dev-gencat-features' }.freeze
+# DECIDIM_VERSION = { git: 'https://github.com/gencat/decidim', tag: 'v0.18-dev-gencat-features' }.freeze
+DECIDIM_VERSION = { path: '../decidim-fork' }.freeze
 
 gem "decidim", DECIDIM_VERSION
 
 #### Custom gems and modifciations block start ####
-gem 'decidim-department_admin', git: 'https://github.com/gencat/decidim-department-admin.git', tag: 'v0.0.1'
+gem 'decidim-department_admin', git: 'https://github.com/gencat/decidim-department-admin.git', tag: 'v0.0.2'
 gem 'decidim-process-extended', path: 'decidim-process-extended'
 gem 'decidim-espais-estables', path: 'decidim-espais-estables'
 gem 'decidim-regulations', path: 'decidim-regulations'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,22 +1,7 @@
 GIT
-  remote: https://github.com/gencat/decidim-department-admin.git
-  revision: 11f7bbe64a04135df17c1f1708b925bf9789a3d1
-  tag: v0.0.2
-  specs:
-    decidim-department_admin (0.0.1)
-      decidim-core (>= 0.16.1)
-
-GIT
-  remote: https://github.com/gencat/decidim-verifications-members_picker.git
-  revision: c72facbc79dd4c4d8753a1330a6978ad7259f746
-  tag: 0.0.2
-  specs:
-    decidim-verifications-members_picker (0.0.2)
-      decidim-core (>= 0.16.0)
-      decidim-verifications (>= 0.16.0)
-
-PATH
-  remote: ../decidim-fork
+  remote: https://github.com/gencat/decidim
+  revision: d7ff93d06ff8c15c0c0db5524f74ed33a5cba3ca
+  tag: v0.18-dev-gencat-features
   specs:
     decidim (0.18.0.dev)
       decidim-accountability (= 0.18.0.dev)
@@ -201,6 +186,23 @@ PATH
       sassc-rails (~> 1.3)
     decidim-verifications (0.18.0.dev)
       decidim-core (= 0.18.0.dev)
+
+GIT
+  remote: https://github.com/gencat/decidim-department-admin.git
+  revision: 11f7bbe64a04135df17c1f1708b925bf9789a3d1
+  tag: v0.0.2
+  specs:
+    decidim-department_admin (0.0.1)
+      decidim-core (>= 0.16.1)
+
+GIT
+  remote: https://github.com/gencat/decidim-verifications-members_picker.git
+  revision: c72facbc79dd4c4d8753a1330a6978ad7259f746
+  tag: 0.0.2
+  specs:
+    decidim-verifications-members_picker (0.0.2)
+      decidim-core (>= 0.16.0)
+      decidim-verifications (>= 0.16.0)
 
 PATH
   remote: decidim-admin-search_user

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,22 @@
 GIT
-  remote: https://github.com/gencat/decidim
-  revision: d7ff93d06ff8c15c0c0db5524f74ed33a5cba3ca
-  tag: v0.18-dev-gencat-features
+  remote: https://github.com/gencat/decidim-department-admin.git
+  revision: 11f7bbe64a04135df17c1f1708b925bf9789a3d1
+  tag: v0.0.2
+  specs:
+    decidim-department_admin (0.0.1)
+      decidim-core (>= 0.16.1)
+
+GIT
+  remote: https://github.com/gencat/decidim-verifications-members_picker.git
+  revision: c72facbc79dd4c4d8753a1330a6978ad7259f746
+  tag: 0.0.2
+  specs:
+    decidim-verifications-members_picker (0.0.2)
+      decidim-core (>= 0.16.0)
+      decidim-verifications (>= 0.16.0)
+
+PATH
+  remote: ../decidim-fork
   specs:
     decidim (0.18.0.dev)
       decidim-accountability (= 0.18.0.dev)
@@ -186,23 +201,6 @@ GIT
       sassc-rails (~> 1.3)
     decidim-verifications (0.18.0.dev)
       decidim-core (= 0.18.0.dev)
-
-GIT
-  remote: https://github.com/gencat/decidim-department-admin.git
-  revision: 6ff8f1a6c294498e0d44f20d2d73bca023294ee9
-  tag: v0.0.1
-  specs:
-    decidim-department_admin (0.0.1)
-      decidim-core (>= 0.16.1)
-
-GIT
-  remote: https://github.com/gencat/decidim-verifications-members_picker.git
-  revision: c72facbc79dd4c4d8753a1330a6978ad7259f746
-  tag: 0.0.2
-  specs:
-    decidim-verifications-members_picker (0.0.2)
-      decidim-core (>= 0.16.0)
-      decidim-verifications (>= 0.16.0)
 
 PATH
   remote: decidim-admin-search_user
@@ -775,7 +773,7 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.6)
-    unicode-display_width (1.5.0)
+    unicode-display_width (1.6.0)
     valid_email2 (2.3.1)
       activemodel (>= 3.2)
       mail (~> 2.5)


### PR DESCRIPTION
#### :tophat: What? Why?
Prevent department_admin of being displayed as a component.

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [-] Add documentation regarding the feature 
- [-] Add/modify seeds
- [-] Add tests
- [x] Depend upon department_admin v0.0.2.

#### Sreenshots
![imatge](https://user-images.githubusercontent.com/199462/57463655-7cb08d80-727b-11e9-9387-7d92eb5e6112.png)
