### PR TITLE
[CONFIG] Ensure department_admin gem is loaded after decidim-core.

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -8,6 +8,8 @@ Bundler.require(*Rails.groups)
 
 module Participa
   class Application < Rails::Application
+    config.railties_order = [:main_app, Decidim::DepartmentAdmin::Engine, :all]
+
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.1
     config.i18n.available_locales = %w(en ca es oc)


### PR DESCRIPTION
#### :tophat: What? Why?
In order to correctly override Decidim's artifacts, we must make sure that Decidim is loaded before decidim-department_admin gem.

#### :pushpin: Related Issues
- Related to #51 
