### PR TITLE
Upgrade decidim-department_admin module to latest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Change Log
 **Upgrade notes:**
+
+- **Changed**: In order to get the feature "admin list has an area column" this PR upgrades `decidim-department_admin` module. [#95](https://github.com/gencat/participa/pull/95)
 - **Added**: Separate `participatory_processes` by `process_group` in `select_recipients_to_deliver` in the admin's newsletter page. [#89](https://github.com/gencat/participa/pull/89)
 - **Changed**: Stop department_admin from being displayed as a component. [#88](https://github.com/gencat/participa/pull/88)
 - **Changed**: Hide `assembly_type` filter from `Assembly` index page as per request of Product Owner [#87](https://github.com/gencat/participa/pull/87)

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ DECIDIM_VERSION = { git: 'https://github.com/gencat/decidim', branch: 'newslette
 gem "decidim", DECIDIM_VERSION
 
 #### Custom gems and modifciations block start ####
-gem 'decidim-department_admin', git: 'https://github.com/gencat/decidim-department-admin.git', tag: 'v0.0.3'
+gem 'decidim-department_admin', git: 'https://github.com/gencat/decidim-department-admin.git', tag: 'v0.0.4'
 gem 'decidim-process-extended', path: 'decidim-process-extended'
 gem 'decidim-espais-estables', path: 'decidim-espais-estables'
 gem 'decidim-regulations', path: 'decidim-regulations'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -189,10 +189,10 @@ GIT
 
 GIT
   remote: https://github.com/gencat/decidim-department-admin.git
-  revision: 8b0aa384602448b88abb43d89f4c23569b591262
-  tag: v0.0.3
+  revision: b463cbb738ec38a0be3f352cc95d243d5df50ff9
+  tag: v0.0.4
   specs:
-    decidim-department_admin (0.0.3)
+    decidim-department_admin (0.0.4)
       decidim-core (>= 0.16.1)
 
 GIT


### PR DESCRIPTION
#### :tophat: What? Why?
In order to  get the feature "admin list has an area column" this PR upgrades `decidim-department_admin` module.

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [x] upgrade decidim-department_admin to v0.0.4.

### :camera: Screenshots (optional)
![image](https://user-images.githubusercontent.com/199462/58085985-118d8200-7bbe-11e9-9dc6-b53afcdfdf87.png)
