### PR TITLE
Revert application default time zone to UTC

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -9,7 +9,6 @@ Bundler.require(*Rails.groups)
 module Participa
   class Application < Rails::Application
     config.railties_order = [:main_app, Decidim::DepartmentAdmin::Engine, :all]
-    config.time_zone = 'Madrid'
 
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.1


### PR DESCRIPTION
#### :tophat: What? Why?
Revert application default time zone to UTC
