### PR TITLE
fix when copying process/regulations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change Log
 **Upgrade notes:**
 
+- **Fixed**: Fix assignation of type when copying ParticipatoryProcess [#102](https://github.com/gencat/participa/pull/102)
 - **Fixed**: Fix color share-link button on /meetings path[#101](https://github.com/gencat/participa/pull/101)
 - **Changed**: Use branch decidim 0.18-stable. [#101](https://github.com/gencat/participa/pull/101)
 - **Fixed**: Fix permissions on decidim-type, just admin can access[#101](https://github.com/gencat/participa/pull/101)

--- a/decidim-process-extended/app/commands/decidim/participatory_processes/admin/copy_participatory_process.rb
+++ b/decidim-process-extended/app/commands/decidim/participatory_processes/admin/copy_participatory_process.rb
@@ -69,7 +69,7 @@ module Decidim
             facilitators: @participatory_process.facilitators,
             show_home: @participatory_process.show_home,
             email: @participatory_process.email,
-            decidim_type: @participatory_process.type
+            decidim_type_id: @participatory_process.decidim_type_id
           )
         end
 


### PR DESCRIPTION
#### :tophat: What? Why?
This PR fix when copying process/regulations

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Fix process.type to process.decidim_type_id 

### :camera: Screenshots (optional)
![Description](URL)
