### PR TITLE
[CONF] Change production log level to :info.

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -52,7 +52,7 @@ Rails.application.configure do
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.
   # fatal, error, warn, info, debug
-  config.log_level = :debug
+  config.log_level = :info
   # config.log_level = :warn
 
   # Prepend all log lines with the following tags.


### PR DESCRIPTION
#### :tophat: What? Why?
In order to reduce log volume in the production environment, log level should be setted to the standard Rails log level for production, which is :info.

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [-] Add `CHANGELOG` entry
- [-] Add documentation regarding the feature 
- [-] Add/modify seeds
- [-] Add tests
- [x] Change log level for the production env.
