### PR TITLE
Feature/avoid deletion of regulations group

### DIFF
--- a/decidim-regulations/README.md
+++ b/decidim-regulations/README.md
@@ -1,7 +1,4 @@
 # Decidim::Regulations
-Short description and motivation.
-
-## Usage
 This module produces a "Regulations" participatory space. This participatory space is just like the Participatory Processes space.
 
 The way to add ParticipatoryProcesses to Regulations is to group them into a Process Group and then configure the application with this Process Group's ID. Then this module takes the ParticipatoryProcesses from this group by filtering rows based on the following query:
@@ -27,8 +24,9 @@ Or install it yourself as:
 $ gem install decidim-regulations
 ```
 
-## Contributing
-Contribution directions go here.
+## Overrides
+To avoid admin users to accidentally delete the process group that defines which Processes should appear into Regulations, there's a decorator for the ParticipatoryProcessGroupsController#destroy method. The decorator is delared at `decidim-regulations/app/decorators/decidim/regulations/admin/avoid_deletion_of_regulations_group.rb` and is prepended to the controller in this module's engine `to_prepare` declaration.
+
 
 ## License
 The gem is available as open source under the terms of the [MIT License](http://opensource.org/licenses/MIT).

--- a/decidim-regulations/app/decorators/decidim/regulations/admin/avoid_deletion_of_regulations_group.rb
+++ b/decidim-regulations/app/decorators/decidim/regulations/admin/avoid_deletion_of_regulations_group.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Regulations
+    module Admin
+      # To avoid admin users to delete special process groups
+      #
+      module AvoidDeletionOfRegulationsGroup
+        def destroy
+          forbidden_groups_ids = [
+            Rails.application.config.process.to_s,
+            Rails.application.config.regulation.to_s
+          ]
+          if forbidden_groups_ids.include?(params[:id])
+            flash[:notice] = "Protected ParticipatoryProcessGroup, can't be deleted."
+            redirect_to participatory_process_groups_path
+          else
+            super
+          end
+        end
+      end
+    end
+  end
+end

--- a/decidim-regulations/lib/decidim/regulations/engine.rb
+++ b/decidim-regulations/lib/decidim/regulations/engine.rb
@@ -58,6 +58,13 @@ module Decidim
           end
         end
       end
+
+      # make decorators available to applications that use this Engine
+      config.to_prepare do
+        require 'decidim/regulations/admin/avoid_deletion_of_regulations_group'
+        ::Decidim::ParticipatoryProcesses::Admin::ParticipatoryProcessGroupsController.prepend(Decidim::Regulations::Admin::AvoidDeletionOfRegulationsGroup)
+      end
+
     end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
To avoid admin users to accidentally delete the process group that defines which Processes should appear into Regulations, this PR implements a decorator for the ParticipatoryProcessGroupsController#destroy method.

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [x] task
