### PR TITLE
I18n fix/clarify registration nickname help

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Change Log
 **Upgrade notes:**
 
+
+- **Changed**: Resort participatory process cost field. [#113](https://github.com/gencat/participa/pull/113)
+- **Changed**: Rename translation for participatory process custom fields. [#113](https://github.com/gencat/participa/pull/113)
+- **Changed**: Clarify registration nickname help (remove '@sobrenom'). [#113](https://github.com/gencat/participa/pull/113)
 - **Added**: Decorator for the ParticipatoryProcessGroupsController#destroy method to avoid admin users to accidentally delete the process group that defines regulations. [#110](https://github.com/gencat/participa/pull/110)
 - **Changed**: Upgrade Decidim::DepartmentAdmin module version[#103](https://github.com/gencat/participa/pull/103)
 - **Fixed**: Fix assignation of type when copying ParticipatoryProcess [#102](https://github.com/gencat/participa/pull/102)

--- a/config/locales/ca_core.yml
+++ b/config/locales/ca_core.yml
@@ -25,6 +25,13 @@ ca:
           preview: Vista prèvia
           select_recipients_to_deliver: Seleccioneu els destinataris a lliurar
           subject: Assumpte
+    devise:
+      omniauth_registrations:
+        new:
+          nickname_help: El teu àlies a %{organization}, sense @.
+      registrations:
+        new:
+          nickname_help: El teu àlies a %{organization}, sense @.
     menu:
       meetings_static: Agenda
     notifications_settings:

--- a/config/locales/es_core.yml
+++ b/config/locales/es_core.yml
@@ -25,6 +25,13 @@ es:
           preview: Vista previa
           select_recipients_to_deliver: Seleccionar destinatarios para entregar
           subject: Asunto
+    devise:
+      omniauth_registrations:
+        new:
+          nickname_help: Tu alias (@nickname) en %{organization}, sin @.
+      registrations:
+        new:
+          nickname_help: Tu alias en %{organization}, sin @.
     menu:
       meetings_static: Agenda
     notifications_settings:

--- a/config/locales/oc_core.yml
+++ b/config/locales/oc_core.yml
@@ -178,7 +178,7 @@ oc:
           email_already_exists: Un aute compde utilize era madeisha adreça de corrèu electronic
         new:
           complete_profile: Completatz eth perfil
-          nickname_help: El vostre identificador curt i únic a %{organization}
+          nickname_help: El vostre identificador curt i únic a %{organization}, sense @.
           sign_up: Se vos platz, completatz eth vòste perfil
           subtitle: Se vos platz, ramplitz eth formulari següent entà completar era vòsta inscripcion
           username_help: Nòm public qu'apareish en es vòsti messatges. Damb er objectiu de garantir er anonimat, pòt èster quin nòm que sigue.
@@ -186,7 +186,7 @@ oc:
         new:
           already_have_an_account?: Ja auetz un compde?
           newsletter: Voi arrecéber informacion sus activitat considerabla
-          nickname_help: El vostre identificador curt i únic a %{organization}
+          nickname_help: El vostre identificador curt i únic a %{organization}, sense @.
           sign_in: Entratz
           sign_up: Enregistratz-vos
           sign_up_as:

--- a/decidim-process-extended/app/views/decidim/participatory_processes/admin/participatory_processes/_form.html.erb
+++ b/decidim-process-extended/app/views/decidim/participatory_processes/admin/participatory_processes/_form.html.erb
@@ -91,6 +91,10 @@
         <%= form.text_field :facilitators, label: t(".facilitators") %>
       </div>
 
+      <div class="row column">
+        <%= form.text_field :cost %>
+      </div>
+
       <div class="columns xlarge-6">
         <%= form.translated :text_field, :local_area %>
       </div>
@@ -114,10 +118,6 @@
 
     <div class="row column">
       <%= form.email_field :email %>
-    </div>
-
-    <div class="row column">
-      <%= form.text_field :cost %>
     </div>
 
     <div class="row column">

--- a/decidim-process-extended/config/locales/ca.yml
+++ b/decidim-process-extended/config/locales/ca.yml
@@ -11,9 +11,9 @@ ca:
             appear_home: Sortir al home (imatge)
             cost: Cost
             duration: Durada
-            facilitators: Entitats facilitadores
+            facilitators: Entitats dinamitzadores
             filters: Filtratge
-            has_summary_record: Disposa d'acta
+            has_summary_record: Disposa de retorn
             images: Imatges
             metadata: Metadades
             other: Altres
@@ -26,8 +26,8 @@ ca:
       show:
         area: Departament
         cost: Cost
-        facilitators: Entitats facilitadores
-        has_summary_record: Disposa d'acta
+        facilitators: Entitats dinamitzadores
+        has_summary_record: Disposa de retorn
         'no': 'No'
         promoting_unit: Unitat promotora
         'yes': 'Sí'

--- a/decidim-process-extended/config/locales/es.yml
+++ b/decidim-process-extended/config/locales/es.yml
@@ -11,9 +11,9 @@ es:
             appear_home: Aparecer en home (imagen)
             cost: Coste
             duration: Duración
-            facilitators: Entidades facilitadoras
+            facilitators: Entidades dinamizadoras
             filters: Filtrado
-            has_summary_record: Dispone de acta
+            has_summary_record: Dispone de retorno
             images: Imágenes
             metadata: Metadatos
             other: Otros
@@ -26,8 +26,8 @@ es:
       show:
         area: Departamento
         cost: Coste
-        facilitators: Entidades facilitadoras
-        has_summary_record: Dispone de acta
+        facilitators: Entidades dinamizadoras
+        has_summary_record: Dispone de retorno
         'no': 'No'
         promoting_unit: Unidad promotora
         'yes': 'Sí'

--- a/docs/HOW_TO_UPGRADE.md
+++ b/docs/HOW_TO_UPGRADE.md
@@ -44,6 +44,15 @@ https://github.com/decidim/decidim/blob/master/docs/getting_started.md#keeping-y
 
 ### Temporal fixes
 
+#### Temporal fix: remove the "(@sobrenom)" from registration nickname help
+This fix has already been applied to decidim/decidim:v0.19, but we have a backport for gencat.
+When updating to v0.19, remove the keys:
+- decidim/devise/omniauth_registrations/new/nickname_help
+- decidim/devise/registrations/new/nickname_help
+
+from `config/locales/??_core.yml` files.
+
+#### Temporal fix: proposals originated in meetings
 Meetings with associated proposals (e.g. with proposals originated in the meeting) crash to be rendered. This is because of the presenter used.
 
 There is a bugfix in current master (06/11/2019) but this bugfix has a mispelling bug itself: https://github.com/decidim/decidim/pull/5383/commits/35b69c9cb80fba850109ca9fce0edb97b5280856
@@ -54,7 +63,7 @@ So, we're overriding the proposalPresenter with the correct fix. When participa 
 - decidim-core/app/cells/decidim/coauthorships_cell.rb
 
 ### Existing modules
-These are custom modules  and this is what you have to keep in mind when updating the version of Decidim.
+These are custom modules and this is what you have to keep in mind when updating the version of Decidim.
 
   1. Decidim Espais Estables ("decidim-assemblies")
       This module changes "Assembly" translation for "Governing council". In catalan, "Assamblea" for "Consell rector". and overwrite the file "highlighted_assemblies".


### PR DESCRIPTION
#### :tophat: What? Why?

- Resort participatory process cost field.
- Rename translation for participatory process custom fields.
- Clarify registration nickname help. (remove '@sobrenom')

#### :pushpin: Related Issues
- Related to: 

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [x] Another subtask
