### PR TITLE
[FIX] Set default timezone to Europe/Madrid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change Log
 **Upgrade notes:**
 
+- **Fixed**: Set default timezone to Europe/Madrid [#124](https://github.com/gencat/participa/pull/124)
 - **Changed**: Disable custom loggers. [#121](https://github.com/gencat/participa/pull/121)
 - **Changed**: Resort participatory process cost field. [#113](https://github.com/gencat/participa/pull/113)
 - **Changed**: Rename translation for participatory process custom fields. [#113](https://github.com/gencat/participa/pull/113)

--- a/config/application.rb
+++ b/config/application.rb
@@ -13,6 +13,7 @@ module Participa
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.1
     config.i18n.available_locales = %w(en ca es oc)
+    config.time_zone = 'Europe/Madrid'
 
     # Processes group ids used to determine whether a process is a regulation or a process
     config.process    = 1

--- a/config/application.rb
+++ b/config/application.rb
@@ -13,7 +13,9 @@ module Participa
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.1
     config.i18n.available_locales = %w(en ca es oc)
-    config.time_zone = 'Europe/Madrid'
+    config.time_zone = 'Madrid'
+    config.active_record.default_timezone = :local
+    config.active_record.time_zone_aware_attributes = false
 
     # Processes group ids used to determine whether a process is a regulation or a process
     config.process    = 1


### PR DESCRIPTION
#### :tophat: What? Why?
There is a 1 hour delay in the application respect our timezone region. In this PR, we set Europe/Madrid timezone to default.

#### :pushpin: Related Issues
- Fixes #?

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry

### :camera: Screenshots (optional)
![Description](URL)
