### PR TITLE
Upgrade to department_admin 0.0.9

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ DECIDIM_VERSION = { git: 'https://github.com/decidim/decidim', branch: '0.18-sta
 gem "decidim", DECIDIM_VERSION
 
 #### Custom gems and modifciations block start ####
-gem 'decidim-department_admin', git: 'https://github.com/gencat/decidim-department-admin.git'#, tag: 'v0.0.8'
+gem 'decidim-department_admin', git: 'https://github.com/gencat/decidim-department-admin.git', tag: 'v0.0.9'
 gem 'decidim-process-extended', path: 'decidim-process-extended'
 gem 'decidim-espais-estables', path: 'decidim-espais-estables'
 gem 'decidim-regulations', path: 'decidim-regulations'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -192,9 +192,10 @@ GIT
 
 GIT
   remote: https://github.com/gencat/decidim-department-admin.git
-  revision: c2c4b52b050b6a7cac7f60ace027922cd23d81fd
+  revision: 28faf8d32d9c06bc0265eae9ae6d28136b77983e
+  tag: v0.0.9
   specs:
-    decidim-department_admin (0.0.8)
+    decidim-department_admin (0.0.9)
       decidim-core (>= 0.16.1)
 
 GIT
@@ -557,17 +558,17 @@ GEM
     netrc (0.11.0)
     nio4r (2.5.2)
     nobspw (0.6.1)
-    nokogiri (1.10.8)
+    nokogiri (1.10.9)
       mini_portile2 (~> 2.4.0)
     oauth (0.5.4)
-    oauth2 (1.4.3)
+    oauth2 (1.4.4)
       faraday (>= 0.8, < 2.0)
       jwt (>= 1.0, < 3.0)
       multi_json (~> 1.3)
       multi_xml (~> 0.5)
       rack (>= 1.2, < 3)
-    omniauth (1.9.0)
-      hashie (>= 3.4.6, < 3.7.0)
+    omniauth (1.9.1)
+      hashie (>= 3.4.6)
       rack (>= 1.6.2, < 3)
     omniauth-facebook (4.0.0)
       omniauth-oauth2 (~> 1.2)


### PR DESCRIPTION
#### :tophat: What? Why?
To allow department admins to manage assembly user roles.

### :camera: Screenshots (optional)
![Description](URL)
