### PR TITLE
Upgrade decidim-department_admin to latest

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ DECIDIM_VERSION = { git: 'https://github.com/decidim/decidim', branch: '0.18-sta
 gem "decidim", DECIDIM_VERSION
 
 #### Custom gems and modifciations block start ####
-gem 'decidim-department_admin', git: 'https://github.com/gencat/decidim-department-admin.git', tag: 'v0.0.11'
+gem 'decidim-department_admin', git: 'https://github.com/gencat/decidim-department-admin.git', branch: '0.0.11-stable'
 gem 'decidim-process-extended', path: 'decidim-process-extended'
 gem 'decidim-espais-estables', path: 'decidim-espais-estables'
 gem 'decidim-regulations', path: 'decidim-regulations'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -192,8 +192,8 @@ GIT
 
 GIT
   remote: https://github.com/gencat/decidim-department-admin.git
-  revision: f53df60eb109d3d3a99d66e5836d902a26aa0903
-  tag: v0.0.11
+  revision: f2bec89911278816166e6fba2786a29e0ef7cf17
+  branch: 0.0.11-stable
   specs:
     decidim-department_admin (0.0.11)
       decidim-core (>= 0.16.1)


### PR DESCRIPTION
#### :tophat: What? Why?
Apply the patch in https://github.com/gencat/decidim-department-admin/pull/27 that is compatible with current Decidim version in participa, decidim v0.18.

The compatible version can be found in latest version of the branch `0.0.11-stable` in department_admin: https://github.com/gencat/decidim-department-admin/tree/0.0.11-stable
