### PR TITLE
fix on edit debates dates not saving correctly

### DIFF
--- a/app/views/decidim/debates/admin/debates/_form.html.erb
+++ b/app/views/decidim/debates/admin/debates/_form.html.erb
@@ -1,0 +1,42 @@
+<div class="card">
+  <div class="card-divider">
+    <h2 class="card-title"><%= title %></h2>
+  </div>
+
+  <div class="card-section">
+    <div class="row column">
+      <%= form.translated :text_field, :title, autofocus: true %>
+    </div>
+
+    <div class="row column">
+      <%= form.translated :editor, :description %>
+    </div>
+
+    <div class="row column">
+      <%= form.translated :editor, :instructions %>
+    </div>
+
+    <div class="row column">
+      <%= form.translated :editor, :information_updates %>
+    </div>
+    <% if @debate then %>
+        <% $start_time = @debate.start_time.strftime('%d/%m/%Y %H:%M') %>
+        <% $end_time = @debate.end_time.strftime('%d/%m/%Y %H:%M') %>
+    <% else %>
+        <% $start_time = '' %>
+        <% $end_time = '' %>
+    <% end %>
+    <div class="row">
+      <div class="column xlarge-6">
+        <%= form.datetime_field :start_time, :value => $start_time %>
+      </div>
+      <div class="column xlarge-6">
+        <%= form.datetime_field :end_time, :value => $end_time %>
+      </div>
+    </div>
+
+    <div class="row column">
+      <%= form.categories_select :decidim_category_id, current_participatory_space.categories, prompt: "", disable_parents: false %>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
#### :tophat: What? Why?

fix on dates when edit debates, error "can not be blank" given when date was not blank and not edited

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` entry
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)
![Description](URL)
