### PR TITLE
Fix migration version on schema.rb

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_20_095872) do
+ActiveRecord::Schema.define(version: 2020_05_18_163673) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "ltree"


### PR DESCRIPTION
#### :tophat: What? Why?

The schema.rb file has an incorrect migration version

#### :pushpin: Related Issues

#### :clipboard: Subtasks

### :camera: Screenshots (optional)
