### PR TITLE
Fix postgres container configuration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,8 @@ services:
     image: postgres
     volumes:
       - pg-data:/var/lib/postgresql/data
+    environment:
+      POSTGRES_PASSWORD: admin
     ports:
       - 5432:5432
   redis:


### PR DESCRIPTION
#### :tophat: What? Why?

The postgres image needs a super user password

```
pg_1     | Error: Database is uninitialized and superuser password is not specified.
pg_1     |        You must specify POSTGRES_PASSWORD to a non-empty value for the
pg_1     |        superuser. For example, "-e POSTGRES_PASSWORD=password" on "docker run".
pg_1     |
pg_1     |        You may also use "POSTGRES_HOST_AUTH_METHOD=trust" to allow all
pg_1     |        connections without a password. This is *not* recommended.
pg_1     |
pg_1     |        See PostgreSQL documentation about "trust":
pg_1     |        https://www.postgresql.org/docs/current/auth-trust.html
gencat_participa_pg_1 exited with code 1
```

#### :pushpin: Related Issues

#### :clipboard: Subtasks

### :camera: Screenshots (optional)
