### PR TITLE
Fix wrong Gencat logo in top left Home

### DIFF
--- a/app/assets/stylesheets/general/_header.scss
+++ b/app/assets/stylesheets/general/_header.scss
@@ -23,13 +23,14 @@
         }
     }
     .logo-wrapper{
+        display: inline-block;
         span{
             display: inline-block;
             position: relative;
 
             padding: 0;
             line-height: 1;
-            
+
             color: white;
             font-weight: 600;
             font-size: 1.4em;


### PR DESCRIPTION
#### :tophat: What? Why?

This fixes the top left Home's logo that now is cut.

#### :pushpin: Related Issues
- Fixes #164 

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` entry
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)

**Before**

![image](https://user-images.githubusercontent.com/9702463/97407378-e2bf2380-18fa-11eb-8394-e97c56383e61.png)

**After**

![image](https://user-images.githubusercontent.com/9702463/97407498-05e9d300-18fb-11eb-8e07-32264b0a0d52.png)

