### PR TITLE
fix meeting dates

### DIFF
--- a/app/decorators/decidim/meetings/admin/meeting_form_decorator.rb
+++ b/app/decorators/decidim/meetings/admin/meeting_form_decorator.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+Decidim::Meetings::Admin::MeetingForm.class_eval do
+    def map_model(model)
+        self.services = model.services.map do |service|
+            MeetingServiceForm.new(service)
+        end
+
+        self.decidim_category_id = model.categorization.decidim_category_id if model.categorization
+        self.start_time = model.start_time.strftime('%d/%m/%Y %H:%M') if model.start_time.present?
+        self.end_time = model.end_time.strftime('%d/%m/%Y %H:%M') if model.end_time.present?
+        presenter = Decidim::Meetings::MeetingPresenter.new(model)
+        self.title = presenter.title(all_locales: true)
+        self.description = presenter.description(all_locales: true)
+    end
+end
+  

--- a/docs/HOW_TO_UPGRADE.md
+++ b/docs/HOW_TO_UPGRADE.md
@@ -84,6 +84,18 @@ These are custom modules and this is what you have to keep in mind when updating
         * ES: "Asamblea" for "Consejo de participación"
 
       Modified files are:
+#### Temporal fix: format meetings's start_time / end_time in meeting_form.rb map_model method
+
+Currently, in the file:
+- app/forms/decorators/decidim/meetings/admin/meeting_form_decorator.rb
+we have overrided `def map_model(model)` method to format start_time and end_time fields
+
+The reason for this, is that a wrong format arrived to from_params method on Rectify form
+This happened only when after having created a meeting with start_time / end_time, we wanted to edit it and change only one date field, this is only start_time or end_time.
+In that moment, de form date's validation fields threw an error because the other date field was in wrong format, so form_builder wasn't able to assign to form.
+
+In next versions, this issue will be patched in `decidim/decidim`, so this override could be removed:
+- app/forms/decorators/decidim/meetings/admin/meeting_form_decorator.rb
 
       * `config/locales/`
         * Copy the locale files from Decidim (decidim-assemblies), and change the string "Assembly" to the correct one


### PR DESCRIPTION

#### :tophat: What? Why?

When editing a existing meeting with Start / End dates, and only wanted to change one of the dates, the form validator threw an error because the other unchanged date field wasn't in wrong format, so form builder couldn't assign it to form.
This causes that this field was unassigned to form, so when meeting's form validation field checked it, threw and error.

#### :pushpin: Related Issues
- Related to #188 #178 
- Fixes #?

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` entry
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)
![Description](URL)
