### PR TITLE
Fix style on user registration nickname field when display is small

### DIFF
--- a/app/assets/stylesheets/general/_fixes.scss
+++ b/app/assets/stylesheets/general/_fixes.scss
@@ -3,3 +3,7 @@
         top: 7px;
     }
 }
+
+.user-nickname label .row > span:first-child:first-of-type {
+  padding: 0px;
+}


### PR DESCRIPTION
#### :tophat: What? Why?
When the screen is small in the user's nickname field on the registration form, the label appears in the wrong position.

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` entry
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)
The nickname is not showed correctly
![wrong_position](https://user-images.githubusercontent.com/5037794/98379572-bff1e500-2047-11eb-9627-7f32c0a3de66.png)

The nickname now is fixed
![correct_position](https://user-images.githubusercontent.com/5037794/98379719-e3b52b00-2047-11eb-821e-de98ca84c3f6.png)
