### PR TITLE
Override style for header input search form

### DIFF
--- a/app/assets/stylesheets/general/_header.scss
+++ b/app/assets/stylesheets/general/_header.scss
@@ -44,4 +44,14 @@
             }
         }
     }
+    .topbar__search input{
+      background: $white;
+      color: $grayHover;
+      &::placeholder{
+        color: $grayLogoNavbar;
+      }
+    }
+    .topbar__search:not(:focus-within) button{
+      color: rgba(255, 255, 255, 0.8);
+    }
 }


### PR DESCRIPTION
#### :tophat: What? Why?
The search input form on header is dark by default. Setting it with a white background and fix the lens icon color will improve the user experience.

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` entry
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)
before:
![Captura de pantalla de 2020-11-17 10-41-52](https://user-images.githubusercontent.com/5037794/99373357-9778af00-28c1-11eb-9b04-91900da9068e.png)

after:
![Captura de pantalla de 2020-11-17 10-40-59](https://user-images.githubusercontent.com/5037794/99373364-9cd5f980-28c1-11eb-9009-355f99e50047.png)
