### PR TITLE
Fix permissions's lack to private participatory space to invited private users

### DIFF
--- a/app/decorators/decidim/participatory_processes/permissions_decorator.rb
+++ b/app/decorators/decidim/participatory_processes/permissions_decorator.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+Decidim::ParticipatoryProcesses::Permissions.class_eval do
+  # To allow invited private space users to acces public view
+  def can_view_private_space?
+    return true unless process.private_space
+    return false unless user
+
+    user.admin ||
+    process.users.include?(user) ||
+    (process.participatory_space_private_users.pluck :decidim_user_id).include?(user.id)
+  end
+end

--- a/app/decorators/decidim/participatory_processes/permissions_decorator.rb
+++ b/app/decorators/decidim/participatory_processes/permissions_decorator.rb
@@ -8,6 +8,6 @@ Decidim::ParticipatoryProcesses::Permissions.class_eval do
 
     user.admin ||
     process.users.include?(user) ||
-    (process.participatory_space_private_users.pluck :decidim_user_id).include?(user.id)
+    process.participatory_space_private_users.where(decidim_user_id: user.id).exists?
   end
 end

--- a/app/decorators/decidim/participatory_space_context_decorator.rb
+++ b/app/decorators/decidim/participatory_space_context_decorator.rb
@@ -9,6 +9,6 @@ Decidim::ParticipatorySpaceContext.class_eval do
 
     current_user.admin ||
     current_participatory_space.users.include?(current_user) ||
-    (current_participatory_space.participatory_space_private_users.pluck :decidim_user_id).include?(current_user.id)
+    current_participatory_space.participatory_space_private_users.where(decidim_user_id: current_user.id).exists?
   end
 end

--- a/app/decorators/decidim/participatory_space_context_decorator.rb
+++ b/app/decorators/decidim/participatory_space_context_decorator.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+Decidim::ParticipatorySpaceContext.class_eval do
+  # Method for current user can visit the space (assembly or proces)
+  def current_user_can_visit_space?
+    return true unless current_participatory_space.try(:private_space?) &&
+                       !current_participatory_space.try(:is_transparent?)
+    return false unless current_user
+
+    current_user.admin ||
+    current_participatory_space.users.include?(current_user) ||
+    (current_participatory_space.participatory_space_private_users.pluck :decidim_user_id).include?(current_user.id)
+  end
+end

--- a/docs/HOW_TO_UPGRADE.md
+++ b/docs/HOW_TO_UPGRADE.md
@@ -233,6 +233,12 @@ In next versions, this issue will be patched in `decidim/decidim`, so this overr
   * `decorators/decidim/proposals/proposals_controller_decorator.rb`
     * Override to add the custom * functionality of best-comments
 
+  * `decorators/decidim/participatory_processes/permissions_decorator.rb`
+    * Override to allow private space users to acces public view
+
+  * `decorators/decidim/participatory_space_context_decorator.rb`
+    * Override to allow private space users to acces public view
+
   Following ones, for some addings or template overrides:
 
   * `app/helpers/decidim/participatory_processes/admin/`


### PR DESCRIPTION
#### :tophat: What? Why?

When in a Private Participatory Process, all invited private users don't have visibility to public's Participatory Process page.
This PR checks and solves this issue to allow them to see that public's page.

#### :pushpin: Related Issues

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` entry
- [X] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)

Before:
![image](https://user-images.githubusercontent.com/9702463/100248961-58d79a00-2f3c-11eb-98dd-ff0a25546cf8.png)

After:
![image](https://user-images.githubusercontent.com/9702463/100249059-70af1e00-2f3c-11eb-990a-923ace65efaf.png)

