### PR TITLE
Fix, temporarily, permission to answer private space questionnaire

### DIFF
--- a/docs/HOW_TO_UPGRADE.md
+++ b/docs/HOW_TO_UPGRADE.md
@@ -235,9 +235,17 @@ In next versions, this issue will be patched in `decidim/decidim`, so this overr
 
   * `decorators/decidim/participatory_processes/permissions_decorator.rb`
     * Override to allow private space users to acces public view
+    * probably removable from Decidim v0.24
 
   * `decorators/decidim/participatory_space_context_decorator.rb`
     * Override to allow private space users to acces public view
+    * probably removable from Decidim v0.24
+
+  * `lib/decidim/has_private_users.rb`
+    * Override to allow private space users to acces public view
+    * Could not use a decorator so the whole class has been copied
+    * Only the `#can_participate?(user)` has been modified
+    * probably removable from Decidim v0.24
 
   Following ones, for some addings or template overrides:
 

--- a/lib/decidim/has_private_users.rb
+++ b/lib/decidim/has_private_users.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "active_support/concern"
+
+module Decidim
+  # A concern with the features needed when you want a model to be able to create
+  # private users
+  module HasPrivateUsers
+    extend ActiveSupport::Concern
+
+    included do
+      has_many :participatory_space_private_users,
+               class_name: "Decidim::ParticipatorySpacePrivateUser",
+               as: :privatable_to,
+               dependent: :destroy
+      has_many :users,
+               through: :participatory_space_private_users,
+               class_name: "Decidim::User",
+               foreign_key: "private_user_to_id"
+
+      def self.visible_for(user)
+        if user
+          return all if user.admin?
+
+          where(
+            id: public_spaces +
+                private_spaces
+                  .joins(:participatory_space_private_users)
+                  .where("decidim_participatory_space_private_users.decidim_user_id = ?", user.id)
+          )
+        else
+          public_spaces
+        end
+      end
+
+      def can_participate?(user)
+        return true unless private_space?
+        return false unless user
+
+        user.admin? || participatory_space_private_users.where(decidim_user_id: user.id).exists?
+      end
+
+      def self.public_spaces
+        where(private_space: false).published
+      end
+
+      def self.private_spaces
+        where(private_space: true)
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?
Private users can not access private ParticipatoryProcesses.
This PR complements https://github.com/gencat/participa/pull/194

#### :pushpin: Related Issues
- Related to https://github.com/gencat/participa/pull/194

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` entry
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)
![Description](URL)
