### PR TITLE
Upgrade decidim-department_admin to v0.0.16

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ DECIDIM_VERSION = { git: 'https://github.com/decidim/decidim', branch: 'release/
 gem "decidim", DECIDIM_VERSION
 
 #### Custom gems and modifciations block start ####
-gem 'decidim-department_admin', git: 'https://github.com/gencat/decidim-department-admin.git', tag: 'v0.0.15'
+gem 'decidim-department_admin', git: 'https://github.com/gencat/decidim-department-admin.git', tag: 'v0.0.16'
 gem 'decidim-process-extended', path: 'decidim-process-extended'
 gem 'decidim-espais-estables', path: 'decidim-espais-estables'
 gem 'decidim-regulations', path: 'decidim-regulations'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -199,10 +199,10 @@ GIT
 
 GIT
   remote: https://github.com/gencat/decidim-department-admin.git
-  revision: 4c4c4690a18d4c29bd7c7ef41e50c007a1af0c5a
-  tag: v0.0.15
+  revision: d66839837163a8045c5c9f9c56fa9d6fe7d810c4
+  tag: v0.0.16
   specs:
-    decidim-department_admin (0.0.15)
+    decidim-department_admin (0.0.16)
       decidim-core (>= 0.21.0)
 
 GIT
@@ -416,7 +416,7 @@ GEM
       delayed_job (>= 3.0, < 5)
     descendants_tracker (0.0.4)
       thread_safe (~> 0.3, >= 0.3.1)
-    devise (4.7.2)
+    devise (4.7.3)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
       railties (>= 4.1.0)
@@ -448,7 +448,7 @@ GEM
       smart_properties
     erbse (0.1.4)
       temple
-    erubi (1.9.0)
+    erubi (1.10.0)
     etherpad-lite (0.3.0)
       rest-client (>= 1.6)
     execjs (2.7.0)
@@ -459,8 +459,9 @@ GEM
       railties (>= 3.0.0)
     faker (2.13.0)
       i18n (>= 1.6, < 2)
-    faraday (1.0.1)
+    faraday (1.1.0)
       multipart-post (>= 1.2, < 3)
+      ruby2_keywords
     ffi (1.13.1)
     figaro (1.2.0)
       thor (>= 0.14.0, < 2)
@@ -582,7 +583,7 @@ GEM
     multipart-post (2.0.0)
     mustache (1.1.1)
     netrc (0.11.0)
-    nio4r (2.5.3)
+    nio4r (2.5.4)
     nobspw (0.6.2)
     nokogiri (1.10.10)
       mini_portile2 (~> 2.4.0)
@@ -625,7 +626,7 @@ GEM
     parser (2.7.2.0)
       ast (~> 2.4.1)
     pg (1.1.4)
-    pg_search (2.3.4)
+    pg_search (2.3.5)
       activerecord (>= 5.2)
       activesupport (>= 5.2)
     polyglot (0.3.5)
@@ -694,7 +695,7 @@ GEM
       virtus (~> 1.0.5)
       wisper (>= 1.6.1)
     redcarpet (3.5.0)
-    redis (4.2.2)
+    redis (4.2.5)
     regexp_parser (1.8.2)
     request_store (1.5.0)
       rack (>= 1.4)
@@ -752,6 +753,7 @@ GEM
       rubocop (>= 0.68.1)
     ruby-ole (1.2.12.2)
     ruby-progressbar (1.10.1)
+    ruby2_keywords (0.0.2)
     ruby_dep (1.5.0)
     rubyzip (2.0.0)
     sass (3.7.4)
@@ -816,7 +818,7 @@ GEM
     truncato (0.7.11)
       htmlentities (~> 4.3.1)
       nokogiri (>= 1.7.0, <= 2.0)
-    tzinfo (1.2.7)
+    tzinfo (1.2.8)
       thread_safe (~> 0.1)
     uber (0.1.0)
     uglifier (4.2.0)


### PR DESCRIPTION
#### :tophat: What? Why?
Upgrade `decidim-department_admin` gem to v0.0.16 to get:
- A user can only belong to one single department.
- When a department_admin is promoted to admin, she looses the role and the department.
