### PR TITLE
Upgrade to fix metrics in show participatory proces

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/decidim/decidim
-  revision: 1f72f330af3835e986ebbcc119494ea63d3ec32d
+  revision: a28130defe378388b3eabca9bde5b074de5d7a32
   branch: release/0.22-stable
   specs:
     decidim (0.22.0)


### PR DESCRIPTION
#### :tophat: What? Why?
The ajax call that retrieves the data for the metrics in participatory processes does not filter by space id due to a bug in decidim/decidim: https://github.com/decidim/decidim/pull/6971 

This PR updates Decidim to latest 0.22 with the bugfix
