### PR TITLE
Add coditional to transition from Decidim v0.22 to v0.23 and up

### DIFF
--- a/decidim-top_comments/app/views/decidim/proposals/proposals/_most_voted_comment.html.erb
+++ b/decidim-top_comments/app/views/decidim/proposals/proposals/_most_voted_comment.html.erb
@@ -24,7 +24,8 @@
   <div class="comment__content">
     <p>
       <span><span class="label alignment <%= alignment == :positive ? 'success' : 'alert' %>"><%= alignment == :positive ? t(".actually_positive") : t(".actually_negattive") %></span><!-- react-text: 161 -->&nbsp;<!-- /react-text --></span>
-        <%= comment.body.to_s %>
+        <%# coditional to transition from non localized body (v0.22) to translated body (v0.23 and up) %>
+        <%= comment.body.is_a?(Hash) ? translated_attribute(comment.body) : comment.body %>
       </p>
   </div>
   <div class="comment__footer">


### PR DESCRIPTION
#### :tophat: What? Why?
Decidim v0.23 refactors Proposal.body making it multilanguage.
This PR makes adapts top_comments to be compatible to both Decidim 0.22 and 0.23 and higher.