### PR TITLE
Add counters and percentages to Top Comments

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,7 +29,7 @@ gem "devise", ">= 4.7.1"
 # due to this alert: https://github.com/gencat/participa/network/alert/decidim-type/Gemfile.lock/nokogiri/open
 gem "nokogiri", ">= 1.10.4"
 # gem sprockets in version 4.0 breaks Decidim.Temporal fix at 10/10/2019
-gem "sprockets", "~> 3.7.2"
+gem "sprockets", "< 4.0.0"
 # Temporal fix for: https://github.com/decidim/decidim/issues/5257 (Solved in v0.19)
 gem "wicked_pdf"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -920,7 +920,7 @@ DEPENDENCIES
   soda-ruby
   spring
   spring-watcher-listen (~> 2.0.0)
-  sprockets (~> 3.7.2)
+  sprockets (< 4.0.0)
   uglifier (~> 4.1)
   web-console
   whenever

--- a/decidim-top_comments/app/controllers/concerns/decidim/proposals/positive_negative_comments.rb
+++ b/decidim-top_comments/app/controllers/concerns/decidim/proposals/positive_negative_comments.rb
@@ -7,22 +7,47 @@ module Decidim
       extend ActiveSupport::Concern
 
       included do
-        helper_method :in_favor_comments, :most_voted_negative_comment, :comment_author, :more_positive_comment, :get_comment, :comment_author_avatar, :count_positive_votes_for_comment, :count_negative_votes_for_comment
+        helper_method :in_favor_comments, :against_comments
+        helper_method :most_voted_in_favor_comments, :most_voted_against_comments, :percentage_of_comments
+        helper_method :in_favor_comments, :most_voted_in_favor_comments, :most_voted_against_comments, :percentage_of_comments
+        helper_method :comment_author, :comment_author_avatar, :count_negative_votes_for_comment
+
+        def proposal_comments(proposal_id)
+          @proposal_comments ||= Decidim::Comments::Comment.where(decidim_commentable_type: "Decidim::Proposals::Proposal", decidim_commentable_id: proposal_id)
+        end
 
         def in_favor_comments
-          @in_favor_comments||= Decidim::Comments::Comment.where(decidim_commentable_type: "Decidim::Proposals::Proposal", decidim_commentable_id: params[:id], alignment: 1)
+          @in_favor_comments||= proposal_comments(params[:id]).where(alignment: 1)
         end
 
-        def more_positive_comment(comment_id, auxID)
-          @more_positive_comment = (ActiveRecord::Base.connection.execute("SELECT * FROM decidim_comments_comment_votes where decidim_comment_id = "+comment_id.to_s+" AND weight = 1").count < ActiveRecord::Base.connection.execute("SELECT * FROM decidim_comments_comment_votes where decidim_comment_id = "+auxID.to_s+" AND weight = 1").count)
+        # Ordered from more votes to less
+        def most_voted_in_favor_comments
+          @most_voted_in_favor_comments = in_favor_comments.joins(:up_votes).select('decidim_comments_comments.*, SUM(decidim_comments_comment_votes.weight) AS vote_sum').group('decidim_comments_comments.*, decidim_comments_comments.id').order(Arel.sql('vote_sum DESC'))
         end
 
-        def get_comment(comment_id)
-          Decidim::Comments::Comment.where(id: comment_id)
+        def percentage_of_comments(num_comments_part)
+          tant_per_one= num_comments_part / total_number_of_comments.to_f
+          (tant_per_one * 100).round(1)
         end
 
-        def most_voted_negative_comment
-          @most_voted_negative_comment = Decidim::Comments::Comment.where(decidim_commentable_type: "Decidim::Proposals::Proposal", decidim_commentable_id: params[:id], alignment: -1)
+        def total_number_of_comments
+          @total_number_of_comments ||= proposal_comments(params[:id]).size
+        end
+
+        # def more_positive_comment(comment_id, auxID)
+        #   @more_positive_comment = (ActiveRecord::Base.connection.execute("SELECT * FROM decidim_comments_comment_votes where decidim_comment_id = "+comment_id.to_s+" AND weight = 1").count < ActiveRecord::Base.connection.execute("SELECT * FROM decidim_comments_comment_votes where decidim_comment_id = "+auxID.to_s+" AND weight = 1").count)
+        # end
+
+        # def get_comment(comment_id)
+        #   Decidim::Comments::Comment.where(id: comment_id)
+        # end
+
+        def against_comments
+          @against_comments||= proposal_comments(params[:id]).where(alignment: -1)
+        end
+
+        def most_voted_against_comments
+          @most_voted_negative_comments = against_comments.joins(:up_votes).select('decidim_comments_comments.*, SUM(decidim_comments_comment_votes.weight) AS vote_sum').group('decidim_comments_comments.*, decidim_comments_comments.id').order(Arel.sql('vote_sum DESC'))
         end
 
         def comment_author(author_id)
@@ -33,9 +58,9 @@ module Decidim
           @comment_author_avatar = Decidim::User.where(id: author_id).pluck(:avatar).first
         end
 
-        def count_positive_votes_for_comment(comment_id)
-          Decidim::Comments::CommentVote.where(decidim_comment_id: comment_id, weight: 1).count
-        end
+        # def count_positive_votes_for_comment(comment_id)
+        #   Decidim::Comments::CommentVote.where(decidim_comment_id: comment_id, weight: 1).count
+        # end
 
         def count_negative_votes_for_comment(comment_id)
           Decidim::Comments::CommentVote.where(decidim_comment_id: comment_id, weight: -1).count

--- a/decidim-top_comments/app/controllers/concerns/decidim/proposals/positive_negative_comments.rb
+++ b/decidim-top_comments/app/controllers/concerns/decidim/proposals/positive_negative_comments.rb
@@ -34,18 +34,11 @@ module Decidim
           @total_number_of_comments ||= proposal_comments(params[:id]).size
         end
 
-        # def more_positive_comment(comment_id, auxID)
-        #   @more_positive_comment = (ActiveRecord::Base.connection.execute("SELECT * FROM decidim_comments_comment_votes where decidim_comment_id = "+comment_id.to_s+" AND weight = 1").count < ActiveRecord::Base.connection.execute("SELECT * FROM decidim_comments_comment_votes where decidim_comment_id = "+auxID.to_s+" AND weight = 1").count)
-        # end
-
-        # def get_comment(comment_id)
-        #   Decidim::Comments::Comment.where(id: comment_id)
-        # end
-
         def against_comments
           @against_comments||= proposal_comments(params[:id]).where(alignment: -1)
         end
 
+        # Ordered from more votes to less
         def most_voted_against_comments
           @most_voted_negative_comments = against_comments.joins(:up_votes).select('decidim_comments_comments.*, SUM(decidim_comments_comment_votes.weight) AS vote_sum').group('decidim_comments_comments.*, decidim_comments_comments.id').order(Arel.sql('vote_sum DESC'))
         end
@@ -57,10 +50,6 @@ module Decidim
         def comment_author_avatar(author_id)
           @comment_author_avatar = Decidim::User.where(id: author_id).pluck(:avatar).first
         end
-
-        # def count_positive_votes_for_comment(comment_id)
-        #   Decidim::Comments::CommentVote.where(decidim_comment_id: comment_id, weight: 1).count
-        # end
 
         def count_negative_votes_for_comment(comment_id)
           Decidim::Comments::CommentVote.where(decidim_comment_id: comment_id, weight: -1).count

--- a/decidim-top_comments/app/views/decidim/proposals/proposals/_most_voted_comment.html.erb
+++ b/decidim-top_comments/app/views/decidim/proposals/proposals/_most_voted_comment.html.erb
@@ -34,7 +34,6 @@
         <svg class="icon icon--small icon-chevron-top">
           <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="<%= asset_path('decidim/icons.svg#icon-chevron-top') %>"></use>
         </svg>
-        <%#= count_positive_votes_for_comment(comment.id) %>
         <%= comment.vote_sum %>
       </button>
       <button class="" disabled="">

--- a/decidim-top_comments/app/views/decidim/proposals/proposals/_most_voted_comment.html.erb
+++ b/decidim-top_comments/app/views/decidim/proposals/proposals/_most_voted_comment.html.erb
@@ -34,7 +34,8 @@
         <svg class="icon icon--small icon-chevron-top">
           <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="<%= asset_path('decidim/icons.svg#icon-chevron-top') %>"></use>
         </svg>
-        <%= count_positive_votes_for_comment(comment.id) %>
+        <%#= count_positive_votes_for_comment(comment.id) %>
+        <%= comment.vote_sum %>
       </button>
       <button class="" disabled="">
         <svg class="icon icon--small icon-chevron-bottom">

--- a/decidim-top_comments/app/views/decidim/proposals/proposals/_most_voted_comments.html.erb
+++ b/decidim-top_comments/app/views/decidim/proposals/proposals/_most_voted_comments.html.erb
@@ -1,27 +1,18 @@
 <div class="row small-up-1 smallmedium-up-2 mediumlarge-up-2 large-up-2 card-grid">
 	<div id="most-voted-comments-favor" class="column">
 		<p class="part-paragraf">
-				<svg class="icon  icon-thumb-up">
+				<svg class="icon icon-thumb-up">
 					<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="<%= asset_path('decidim/icons.svg#icon-thumb-up') %>"></use>
 				</svg>
-				<%= t(".positive") %>
+				<span id="num-in-favor-comments"><%= in_favor_comments.size %></span>
+			  <%= t(".positive").downcase %>
+			  <span id="percent-in-favor-comments">(<%= percentage_of_comments(in_favor_comments.size) %>%)</span>
 		</p>
-		<% auxCommentId = 0 %>
-		<% if in_favor_comments.any? %>
-			<% in_favor_comments.each do |comment| %>
-				<% if (more_positive_comment(comment.id, auxCommentId) == false) %>
-					<% auxCommentId = comment.id %>
-				<% end %>
-			<% end %>
-			<% get_comment(auxCommentId).each do |comment| %>
-			<% if count_positive_votes_for_comment(comment.id) > 0 %>
-					<div class="comment-thread comment-in-favor">
-						<%= render partial: "most_voted_comment", locals: {comment: comment, alignment: :positive} %>
-					</div>
-				<% else %>
-					<p class="part-cont-5"><%= t(".no_results") %></p>
-				<% end %>
-			<% end %>
+		<% if most_voted_in_favor_comments.any? %>
+			<% comment= most_voted_in_favor_comments.first %>
+			<div class="comment-thread comment-in-favor">
+				<%= render partial: "most_voted_comment", locals: {comment: comment, alignment: :positive} %>
+			</div>
 		<% else %>
 			<p class="part-cont-5"><%= t(".no_results") %></p>
 		<% end %>
@@ -29,26 +20,19 @@
 	<% auxCommentId = 0 %>
 	<div id="most-voted-comments-against" class="column">
 		<p class="part-paragraf">
-			<svg class="icon  icon-thumb-down">
+			<svg class="icon icon-thumb-down">
 					<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="<%= asset_path('decidim/icons.svg#icon-thumb-down') %>"></use>
 			</svg>
-			<%= t(".negative") %>
+				<span id="num-against-comments"><%= against_comments.size %></span>
+				<%= t(".negative").downcase %>
+			  <span id="percent-against-comments">(<%= percentage_of_comments(against_comments.size) %>%)</span>
+
 		</p>
-		<% if most_voted_negative_comment.any? %>
-			<% most_voted_negative_comment.each do |comments| %>
-				<% if (more_positive_comment(comments.id, auxCommentId) == false) %>
-					<% auxCommentId = comments.id %>
-				<% end %>
-			<% end %>
-				<% get_comment(auxCommentId).each do |comment| %>
-					<% if count_positive_votes_for_comment(comment.id) > 0 %>
-						<div class="comment-thread comment-against">
-							<%= render partial: "most_voted_comment", locals: {comment: comment, alignment: :negative} %>
-						</div>
-				<% else %>
-					<p class="part-cont-5"><%= t(".no_results") %></p>
-				<% end %>
-			<% end %>
+		<% if most_voted_against_comments.any? %>
+			<% comment= most_voted_against_comments.first %>
+			<div class="comment-thread comment-against">
+				<%= render partial: "most_voted_comment", locals: {comment: comment, alignment: :negative} %>
+			</div>
 		<% else %>
 			<p class="part-cont-5"><%= t(".no_results") %></p>
 		<% end %>

--- a/decidim-top_comments/config/locales/ca.yml
+++ b/decidim-top_comments/config/locales/ca.yml
@@ -10,4 +10,4 @@ ca:
         most_voted_comments:
           positive: A favor
           negative: En contra
-          no_results: No s'han trobat resultats
+          no_results: Cap comentari amb vots

--- a/decidim-top_comments/config/locales/en.yml
+++ b/decidim-top_comments/config/locales/en.yml
@@ -14,4 +14,4 @@ en:
         most_voted_comments:
           positive: In favor
           negative: Against
-          no_results: No results found
+          no_results: No comments with votes found

--- a/decidim-top_comments/config/locales/es.yml
+++ b/decidim-top_comments/config/locales/es.yml
@@ -10,4 +10,4 @@ es:
         most_voted_comments:
           positive: A favor
           negative: En contra
-          no_results: No se han encontrado resultados
+          no_results: No se han encontrado comentarios con votos

--- a/decidim-top_comments/config/locales/oc.yml
+++ b/decidim-top_comments/config/locales/oc.yml
@@ -10,4 +10,4 @@ oc:
         most_voted_comments:
           positive: A favor
           negative: En contra
-          no_results: No s'han trobat resultats
+          no_results: Cap comentari amb vots

--- a/decidim-top_comments/spec/system/most_voted_comments_spec.rb
+++ b/decidim-top_comments/spec/system/most_voted_comments_spec.rb
@@ -7,8 +7,8 @@ describe "Most Voted Comments", type: :system do
     create(
       :organization,
       name: "Participa Gencat",
-      default_locale: :ca,
-      available_locales: [:ca],
+      default_locale: :en,
+      available_locales: [:ca, :en],
     )
   end
   # forcing nickname and slug as they are randomly failing in Decidim v0.22, remove them after upgrading to v0.23
@@ -28,7 +28,7 @@ describe "Most Voted Comments", type: :system do
     it "renders the block empty" do
       visit resource_path
       expect(page).to have_selector("#most-voted-comments")
-      expect(page).to have_content("COMENTARIS MÉS VOTATS")
+      expect(page).to have_content("MOST VOTED COMMENTS")
       expect(page).to_not have_selector(".comment-in-favor")
       expect(page).to_not have_selector(".comment-against")
     end
@@ -43,6 +43,24 @@ describe "Most Voted Comments", type: :system do
       visit resource_path
       expect(page).to_not have_selector(".comment-in-favor")
       expect(page).to_not have_selector(".comment-against")
+    end
+
+    it "shows the number of each kind of comments" do
+      visit resource_path
+
+      expect(page).to have_selector("#num-in-favor-comments")
+      counter= find("#num-in-favor-comments")
+      expect(counter).to have_text("1")
+      expect(page).to have_selector("#percent-in-favor-comments")
+      counter= find("#percent-in-favor-comments")
+      expect(counter).to have_text("(33.3%)")
+
+      expect(page).to have_selector("#num-against-comments")
+      counter= find("#num-against-comments")
+      expect(counter).to have_text("1")
+      expect(page).to have_selector("#percent-against-comments")
+      counter= find("#percent-against-comments")
+      expect(counter).to have_text("(33.3%)")
     end
 
     context "when votes go to the neutral comment" do


### PR DESCRIPTION
#### :tophat: What? Why?
This PR adds counters and percentages to Top Comments block.
For each kind of comments, in favor and against, it renders the count and the percentage.

This PR also improves,  in performance terms, the algorithm to select the most voted comment of each kind.