### PR TITLE
Use Rails 5.2 defaults

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -13,7 +13,7 @@ module Participa
     config.railties_order = [:main_app, Decidim::DepartmentAdmin::Engine, :all]
 
     # Initialize configuration defaults for originally generated Rails version.
-    config.load_defaults 5.1
+    config.load_defaults 5.2
     config.i18n.available_locales = %w(en ca es oc)
     config.time_zone = "Madrid"
 


### PR DESCRIPTION
#### :tophat: What? Why?
We're in Rails 5.2 and there's no need to use rails 5.1 defaults.