### PR TITLE
Port fixes to questionnaires and templates

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@
 source "https://rubygems.org"
 
 ruby RUBY_VERSION
-DECIDIM_VERSION = { git: "https://github.com/CodiTramuntana/decidim", branch: "backport/8143_to_release/0.24-stable" }.freeze
+DECIDIM_VERSION = { git: "https://github.com/CodiTramuntana/decidim", branch: "release/0.24-stable" }.freeze
 
 gem "decidim", DECIDIM_VERSION
 gem "decidim-templates", DECIDIM_VERSION

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/CodiTramuntana/decidim
-  revision: e8baa6e768473d7f92ba27bec3db08d0d828e369
-  branch: backport/8143_to_release/0.24-stable
+  revision: a851ee6feb311c3c4412d733d6773d9f94f2d0b7
+  branch: release/0.24-stable
   specs:
     decidim (0.24.3)
       decidim-accountability (= 0.24.3)
@@ -491,7 +491,7 @@ GEM
       rest-client (>= 1.6)
     eventmachine (1.2.7)
     eventmachine_httpserver (0.2.1)
-    excon (0.82.0)
+    excon (0.84.0)
     execjs (2.8.1)
     factory_bot (4.11.1)
       activesupport (>= 3.0.0)
@@ -543,7 +543,7 @@ GEM
     graphiql-rails (1.4.11)
       railties
       sprockets-rails
-    graphql (1.12.12)
+    graphql (1.12.13)
     hashdiff (1.0.1)
     hashie (3.6.0)
     highline (2.0.3)
@@ -624,7 +624,7 @@ GEM
     method_source (1.0.0)
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2021.0225)
+    mime-types-data (3.2021.0704)
     mini_magick (4.11.0)
     mini_mime (1.1.0)
     mini_portile2 (2.5.3)
@@ -834,7 +834,7 @@ GEM
       ffi (~> 1.12)
     ruby2_keywords (0.0.4)
     ruby_dep (1.5.0)
-    rubyzip (2.3.0)
+    rubyzip (2.3.2)
     sass (3.7.4)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)


### PR DESCRIPTION
#### :tophat: What? Why?
Upgrade to decidim `release/0.24-stable` in CodiTramuntana's fork.

Ports:
- Fully copy question's display_conditions from template #8200
- Fix create questionnaire from template when no template is selected #8185
- Fix ordering of question matrix_rows in templates #8186
