### PR TITLE
upgrade decidim-department_areas to version 3.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gem "decidim-templates", DECIDIM_VERSION
 #### Custom gems and modifciations block start ####
 gem "decidim-admin-extended", path: "decidim-admin-extended"
 gem "decidim-challenges", "0.0.7", git: "https://github.com/gencat/decidim-challenges.git"
-gem "decidim-department_admin", "~> 0.3.2", git: "https://github.com/gencat/decidim-department-admin.git"
+gem "decidim-department_admin", "~> 0.3.3", git: "https://github.com/gencat/decidim-department-admin.git"
 gem "decidim-espais-estables", path: "decidim-espais-estables"
 gem "decidim-home", path: "decidim-home"
 gem "decidim-process-extended", path: "decidim-process-extended"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -215,9 +215,9 @@ GIT
 
 GIT
   remote: https://github.com/gencat/decidim-department-admin.git
-  revision: e6d271c404447ef8d71a41cb88ea119830646bdd
+  revision: 5d0922ca2448dc7753ab952520faea1457321572
   specs:
-    decidim-department_admin (0.3.2)
+    decidim-department_admin (0.3.3)
       decidim-core (~> 0.24.2)
 
 GIT
@@ -964,7 +964,7 @@ DEPENDENCIES
   decidim!
   decidim-admin-extended!
   decidim-challenges (= 0.0.7)!
-  decidim-department_admin (~> 0.3.2)!
+  decidim-department_admin (~> 0.3.3)!
   decidim-dev!
   decidim-espais-estables!
   decidim-home!


### PR DESCRIPTION
Upgrade version of gem decidim-department_admin to 3.3 to get fix: Department admin on "millora visualització rols" when the user was in table department_admin_areas and has no role "department_admin" it shows like if it was a department_admin

#### :tophat: What? Why?


#### :pushpin: Related Issues
- Related to https://github.com/gencat/decidim-department-admin/pull/45
- Fixes https://github.com/gencat/decidim-department-admin/pull/44

#### :clipboard: Subtasks
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)
![Description](URL)
