### PR TITLE
Fix serialization of participatory_space name

### DIFF
--- a/decidim-process-extended/app/serializers/decidim/participatory_processes/participatory_process_serializer.rb
+++ b/decidim-process-extended/app/serializers/decidim/participatory_processes/participatory_process_serializer.rb
@@ -26,7 +26,7 @@ module Decidim
           scope_name_ca: process.scope&.name.try(:[], "ca"),
           department_id: process.area&.id,
           department_name_ca: process.area&.name.try(:[], "ca"),
-          participatory_space: process.participatory_process_group&.name.try(:[], "ca")&.downcase,
+          participatory_space: process.participatory_process_group&.title.try(:[], "ca")&.downcase,
           normative_type_id: process.decidim_type&.id,
           normative_type_name_ca: process.decidim_type&.name.try(:[], "ca"),
           duration_days: duration_days,

--- a/decidim-process-extended/spec/serializers/decidim/participatory_processes/participatory_process_serializer_spec.rb
+++ b/decidim-process-extended/spec/serializers/decidim/participatory_processes/participatory_process_serializer_spec.rb
@@ -15,6 +15,20 @@ module Decidim::ParticipatoryProcesses
       let(:user) { create :user, organization: organization }
       let(:user_group) { create(:user_group, :verified, organization: organization, users: [user]) }
 
+      context "when there is a process_group" do
+        let!(:process_group) { create :participatory_process_group, organization: organization }
+
+        before do
+          participatory_process.participatory_process_group= process_group
+        end
+
+        describe "#participatory_space" do
+          it "contains the title of the process_group" do
+            expect(subject.serialize).to include(participatory_space: process_group.title["ca"].downcase)
+          end
+        end
+      end
+
       context "when there are proposals" do
         let!(:proposal) { create(:proposal, component: proposals_component) }
 


### PR DESCRIPTION
#### :tophat: What? Why?
The open data exporter to Socrata, when serializing the participatory process, it was using `process_group.name` instead of `process_group.title`. This attribute was changed by the migration `RenameNameColumnToTitleInDecidimParticipatoryProcessGroups` in v0.24.

#### :clipboard: Subtasks
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [x] Add tests
- [ ] Another subtask
