### PR TITLE
Upgrade to decidim-department_admin v0.3.4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gem "decidim-templates", DECIDIM_VERSION
 #### Custom gems and modifciations block start ####
 gem "decidim-admin-extended", path: "decidim-admin-extended"
 gem "decidim-challenges", "0.0.7", git: "https://github.com/gencat/decidim-challenges.git"
-gem "decidim-department_admin", "~> 0.3.3", git: "https://github.com/gencat/decidim-department-admin.git"
+gem "decidim-department_admin", "~> 0.3.4", git: "https://github.com/gencat/decidim-department-admin.git"
 gem "decidim-espais-estables", path: "decidim-espais-estables"
 gem "decidim-home", path: "decidim-home"
 gem "decidim-process-extended", path: "decidim-process-extended"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -215,9 +215,9 @@ GIT
 
 GIT
   remote: https://github.com/gencat/decidim-department-admin.git
-  revision: 5d0922ca2448dc7753ab952520faea1457321572
+  revision: 82287c70b69d5450e8048de0c35a04bfee76249a
   specs:
-    decidim-department_admin (0.3.3)
+    decidim-department_admin (0.3.4)
       decidim-core (~> 0.24.2)
 
 GIT
@@ -964,7 +964,7 @@ DEPENDENCIES
   decidim!
   decidim-admin-extended!
   decidim-challenges (= 0.0.7)!
-  decidim-department_admin (~> 0.3.3)!
+  decidim-department_admin (~> 0.3.4)!
   decidim-dev!
   decidim-espais-estables!
   decidim-home!


### PR DESCRIPTION
#### :tophat: What? Why?
When debugging the problem with meetings DiffRenderer we've found that there's an incompatibility between decidim-department_admin and participa.gencat.cat since version `v0.2.0` but it manifested recently.

It's been solved in: https://github.com/gencat/decidim-department-admin/pull/46

#### :pushpin: Related Issues
- Related to https://github.com/gencat/decidim-department-admin/pull/46
