### PR TITLE
Change department_admin's URL

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,8 +10,8 @@ gem "decidim-templates", DECIDIM_VERSION
 
 #### Custom gems and modifciations block start ####
 gem "decidim-admin-extended", path: "decidim-admin-extended"
-gem "decidim-challenges", "0.0.9", git: "https://github.com/gencat/decidim-challenges.git"
-gem "decidim-department_admin", "~> 0.3.4", git: "https://github.com/gencat/decidim-department-admin.git"
+gem "decidim-challenges", "0.0.9", git: "https://github.com/gencat/decidim-module-challenges.git"
+gem "decidim-department_admin", "~> 0.4.0", git: "https://github.com/gencat/decidim-module-department_admin.git"
 gem "decidim-espais-estables", path: "decidim-espais-estables"
 gem "decidim-home", path: "decidim-home"
 gem "decidim-process-extended", path: "decidim-process-extended"
@@ -22,7 +22,7 @@ gem "decidim-top_comments", path: "decidim-top_comments"
 gem "decidim-type", path: "decidim-type"
 #### Custom gems and modifications block end ####
 
-gem "decidim-idcat_mobil", "0.0.6", git: "https://github.com/gencat/decidim-idcat_mobil.git"
+gem "decidim-idcat_mobil", "0.0.6", git: "https://github.com/gencat/decidim-module-idcat_mobil.git"
 gem "decidim-verifications-members_picker", git: "https://github.com/gencat/decidim-verifications-members_picker.git", tag: "0.0.2"
 gem "rails", "5.2.6"
 gem "soda-ruby", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -207,21 +207,21 @@ GIT
       decidim-core (= 0.24.3)
 
 GIT
-  remote: https://github.com/gencat/decidim-challenges.git
+  remote: https://github.com/gencat/decidim-module-challenges.git
   revision: 1dc599d12eefd0bb678c1c83ccd55d15970b3494
   specs:
     decidim-challenges (0.0.9)
       decidim-core (~> 0.24.2)
 
 GIT
-  remote: https://github.com/gencat/decidim-department-admin.git
-  revision: 82287c70b69d5450e8048de0c35a04bfee76249a
+  remote: https://github.com/gencat/decidim-module-department_admin.git
+  revision: a0f576e459b03710794f7e6264c48a03ae67baaf
   specs:
-    decidim-department_admin (0.3.4)
+    decidim-department_admin (0.4.0)
       decidim-core (~> 0.24.2)
 
 GIT
-  remote: https://github.com/gencat/decidim-idcat_mobil.git
+  remote: https://github.com/gencat/decidim-module-idcat_mobil.git
   revision: 7e202d5d59f9ce9c0c231819e2297599e8939a5c
   specs:
     decidim-idcat_mobil (0.0.6)
@@ -675,7 +675,7 @@ GEM
       oauth2 (~> 1.1)
       omniauth (~> 1.1)
       omniauth-oauth2 (>= 1.6)
-    omniauth-idcat_mobil (0.2.0)
+    omniauth-idcat_mobil (0.2.1)
       omniauth (~> 1.5)
       omniauth-oauth2 (>= 1.4.0, < 2.0)
     omniauth-oauth (1.2.0)
@@ -964,7 +964,7 @@ DEPENDENCIES
   decidim!
   decidim-admin-extended!
   decidim-challenges (= 0.0.9)!
-  decidim-department_admin (~> 0.3.4)!
+  decidim-department_admin (~> 0.4.0)!
   decidim-dev!
   decidim-espais-estables!
   decidim-home!


### PR DESCRIPTION
#### :tophat: What? Why?
The repository URL of the `department_admin` gem has changed. This PR updates the URL in this project's `Gemfile`.

#### :pushpin: Related Issues
- Related to https://github.com/gencat/decidim-module-department_admin/pull/49
