### PR TITLE
Redirect for "futur-europa" url

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -284,8 +284,8 @@ PATH
   remote: decidim-top_comments
   specs:
     decidim-top_comments (0.23.1)
-      decidim-core (>= 0.22)
-      decidim-proposals (>= 0.22)
+      decidim-core (>= 0.24)
+      decidim-proposals (>= 0.24)
       deface (~> 1.5.3)
 
 PATH

--- a/app/assets/javascripts/decidim/participa/regulations.js
+++ b/app/assets/javascripts/decidim/participa/regulations.js
@@ -8,7 +8,7 @@ $( document ).ready(function() {
 
     $('[data-open="processEmbed"]').hide();
 
-    //hoome section correction - meetings count
+    // home section correction - meetings count
     var meetings_home = $(".home-pam__lowlight").find(".home-pam__data").first();
     var last_home = $(".home-pam__highlight").last();
     $(meetings_home).appendTo(last_home);

--- a/config/initializers/future_europe_redirect.rb
+++ b/config/initializers/future_europe_redirect.rb
@@ -1,0 +1,2 @@
+Rails.application.config.middleware.use Middlewares::RedirectMiddleware
+  # config.middleware.insert_before Warden::Manager, Middlewares::RedirectMiddleware

--- a/config/initializers/future_europe_redirect.rb
+++ b/config/initializers/future_europe_redirect.rb
@@ -1,2 +1,3 @@
+# frozen_string_literal: true
+
 Rails.application.config.middleware.use Middlewares::RedirectMiddleware
-  # config.middleware.insert_before Warden::Manager, Middlewares::RedirectMiddleware

--- a/lib/middlewares/redirect_middleware.rb
+++ b/lib/middlewares/redirect_middleware.rb
@@ -1,0 +1,17 @@
+
+module Middlewares
+  class RedirectMiddleware
+    def initialize(app)
+      @app = app
+    end
+
+    def call(env)
+      request = Rack::Request.new(env)
+      if request.path.starts_with?("/futur-europa")
+        [301, {"Location" => request.url.sub("/futur-europa", "/processes/FuturEuropa")}, []]
+      else
+        @app.call(env)
+      end
+    end
+  end
+end

--- a/lib/middlewares/redirect_middleware.rb
+++ b/lib/middlewares/redirect_middleware.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 
 module Middlewares
   class RedirectMiddleware
@@ -8,7 +9,7 @@ module Middlewares
     def call(env)
       request = Rack::Request.new(env)
       if request.path.starts_with?("/futur-europa")
-        [301, {"Location" => request.url.sub("/futur-europa", "/processes/FuturEuropa")}, []]
+        [301, { "Location" => request.url.sub("/futur-europa", "/processes/FuturEuropa") }, []]
       else
         @app.call(env)
       end

--- a/spec/features/overrides_and_customizations_spec.rb
+++ b/spec/features/overrides_and_customizations_spec.rb
@@ -4,6 +4,7 @@ require "rails_helper"
 
 describe "Overrides and customizations" do
   it "remove templates translations when Decidim v0.25" do
+    # remove tmp override lib/decidim/has_private_users.rb? https://github.com/gencat/participa/pull/195
     # remove config/locales/ca_templates.yml and config/locales/es_templates.yml
     # when this translations are in Decidim 0.25
     expect(Decidim.version).to be < "0.25"

--- a/spec/models/organizations_spec.rb
+++ b/spec/models/organizations_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-describe "Organizations", type: :system do
+describe "Organizations" do
   let(:organization) { create(:organization) }
 
   context "with backoffice admins" do

--- a/spec/system/future_europe_spec.rb
+++ b/spec/system/future_europe_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe "Futur Europa redirect", type: :system do
+  let(:title_ca) { "El futur d'Europa" }
+  let!(:process) { create(:participatory_process, slug: "FuturEuropa", title: { ca: title_ca }) }
+  let!(:organization) { process.organization }
+
+  before do
+    switch_to_host(organization.host)
+    # visit decidim.root_path
+  end
+
+  it "redirects to the process when /futur-europa is visited" do
+    visit "/futur-europa"
+    expect(page).to have_content(title_ca)
+  end
+end

--- a/spec/system/future_europe_spec.rb
+++ b/spec/system/future_europe_spec.rb
@@ -9,7 +9,6 @@ describe "Futur Europa redirect", type: :system do
 
   before do
     switch_to_host(organization.host)
-    # visit decidim.root_path
   end
 
   it "redirects to the process when /futur-europa is visited" do


### PR DESCRIPTION
#### :tophat: What? Why?
The application should redirect from path `/futur-europa` to the regular url `/processes/FuturEuropa`