### PR TITLE
Upgrade idcat_mobil libs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,7 @@ gem "decidim-top_comments", path: "decidim-top_comments"
 gem "decidim-type", path: "decidim-type"
 #### Custom gems and modifications block end ####
 
-gem "decidim-idcat_mobil", "0.0.6", git: "https://github.com/gencat/decidim-module-idcat_mobil.git"
+gem "decidim-idcat_mobil", "0.0.7"
 gem "decidim-verifications-members_picker", git: "https://github.com/gencat/decidim-verifications-members_picker.git", tag: "0.0.2"
 gem "rails", "5.2.6"
 gem "soda-ruby", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -221,15 +221,6 @@ GIT
       decidim-core (~> 0.24.2)
 
 GIT
-  remote: https://github.com/gencat/decidim-module-idcat_mobil.git
-  revision: 7e202d5d59f9ce9c0c231819e2297599e8939a5c
-  specs:
-    decidim-idcat_mobil (0.0.6)
-      decidim (>= 0.20.0)
-      decidim-core (>= 0.20.0)
-      omniauth-idcat_mobil (~> 0.2.0)
-
-GIT
   remote: https://github.com/gencat/decidim-verifications-members_picker.git
   revision: c72facbc79dd4c4d8753a1330a6978ad7259f746
   tag: 0.0.2
@@ -421,7 +412,7 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
-    css_parser (1.10.0)
+    css_parser (1.11.0)
       addressable
     daemons (1.4.0)
     database_cleaner (2.0.1)
@@ -436,6 +427,10 @@ GEM
     db-query-matchers (0.9.0)
       activesupport (>= 4.0, <= 6.0)
       rspec (~> 3.0)
+    decidim-idcat_mobil (0.0.7)
+      decidim (>= 0.20.0)
+      decidim-core (>= 0.20.0)
+      omniauth-idcat_mobil (~> 0.2.2)
     declarative-builder (0.1.0)
       declarative-option (< 0.2.0)
     declarative-option (0.1.0)
@@ -451,7 +446,7 @@ GEM
       delayed_job (>= 3.0, < 5)
     descendants_tracker (0.0.4)
       thread_safe (~> 0.3, >= 0.3.1)
-    devise (4.8.0)
+    devise (4.8.1)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
       railties (>= 4.1.0)
@@ -499,7 +494,7 @@ GEM
       rest-client (>= 1.6)
     eventmachine (1.2.7)
     eventmachine_httpserver (0.2.1)
-    excon (0.89.0)
+    excon (0.90.0)
     execjs (2.8.1)
     factory_bot (4.11.1)
       activesupport (>= 3.0.0)
@@ -508,26 +503,30 @@ GEM
       railties (>= 3.0.0)
     faker (2.18.0)
       i18n (>= 1.6, < 2)
-    faraday (1.8.0)
+    faraday (1.9.3)
       faraday-em_http (~> 1.0)
       faraday-em_synchrony (~> 1.0)
       faraday-excon (~> 1.1)
-      faraday-httpclient (~> 1.0.1)
+      faraday-httpclient (~> 1.0)
+      faraday-multipart (~> 1.0)
       faraday-net_http (~> 1.0)
-      faraday-net_http_persistent (~> 1.1)
+      faraday-net_http_persistent (~> 1.0)
       faraday-patron (~> 1.0)
       faraday-rack (~> 1.0)
-      multipart-post (>= 1.2, < 3)
+      faraday-retry (~> 1.0)
       ruby2_keywords (>= 0.0.4)
     faraday-em_http (1.0.0)
     faraday-em_synchrony (1.0.0)
     faraday-excon (1.1.0)
     faraday-httpclient (1.0.1)
+    faraday-multipart (1.0.3)
+      multipart-post (>= 1.2, < 3)
     faraday-net_http (1.0.1)
     faraday-net_http_persistent (1.2.0)
     faraday-patron (1.0.0)
     faraday-rack (1.0.0)
-    ffi (1.15.4)
+    faraday-retry (1.0.3)
+    ffi (1.15.5)
     figaro (1.2.0)
       thor (>= 0.14.0, < 2)
     file_validators (2.3.0)
@@ -538,7 +537,7 @@ GEM
       excon (~> 0.71)
       formatador (~> 0.2)
       mime-types
-    fog-local (0.7.0)
+    fog-local (0.8.0)
       fog-core (>= 1.27, < 3.0)
     formatador (0.3.0)
     foundation-rails (6.6.2.0)
@@ -551,13 +550,13 @@ GEM
       activesupport (>= 4.1, < 6.0)
       railties (>= 4.1, < 6.0)
       tzinfo (~> 1.2, >= 1.2.2)
-    geocoder (1.7.0)
+    geocoder (1.7.3)
     globalid (1.0.0)
       activesupport (>= 5.0)
     graphiql-rails (1.4.11)
       railties
       sprockets-rails
-    graphql (1.13.0)
+    graphql (1.13.7)
     hashdiff (1.0.1)
     hashie (3.6.0)
     highline (2.0.3)
@@ -595,18 +594,18 @@ GEM
     jquery-tmpl-rails (1.1.0)
       rails (>= 3.1.0)
     jwt (2.3.0)
-    kaminari (1.2.1)
+    kaminari (1.2.2)
       activesupport (>= 4.1.0)
-      kaminari-actionview (= 1.2.1)
-      kaminari-activerecord (= 1.2.1)
-      kaminari-core (= 1.2.1)
-    kaminari-actionview (1.2.1)
+      kaminari-actionview (= 1.2.2)
+      kaminari-activerecord (= 1.2.2)
+      kaminari-core (= 1.2.2)
+    kaminari-actionview (1.2.2)
       actionview
-      kaminari-core (= 1.2.1)
-    kaminari-activerecord (1.2.1)
+      kaminari-core (= 1.2.2)
+    kaminari-activerecord (1.2.2)
       activerecord
-      kaminari-core (= 1.2.1)
-    kaminari-core (1.2.1)
+      kaminari-core (= 1.2.2)
+    kaminari-core (1.2.2)
     kramdown (2.3.1)
       rexml
     kramdown-parser-gfm (1.1.0)
@@ -639,11 +638,11 @@ GEM
     method_source (1.0.0)
     mime-types (3.4.1)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2021.1115)
+    mime-types-data (3.2022.0105)
     mini_magick (4.11.0)
     mini_mime (1.1.2)
     mini_portile2 (2.6.1)
-    minitest (5.14.4)
+    minitest (5.15.0)
     mixlib-cli (2.1.8)
     mixlib-config (3.0.9)
       tomlrb
@@ -677,7 +676,7 @@ GEM
       oauth2 (~> 1.1)
       omniauth (~> 1.1)
       omniauth-oauth2 (>= 1.6)
-    omniauth-idcat_mobil (0.2.1)
+    omniauth-idcat_mobil (0.2.2)
       omniauth (~> 1.5)
       omniauth-oauth2 (>= 1.4.0, < 2.0)
     omniauth-oauth (1.2.0)
@@ -700,7 +699,7 @@ GEM
     parser (3.0.1.1)
       ast (~> 2.4.1)
     pg (1.1.4)
-    pg_search (2.3.5)
+    pg_search (2.3.6)
       activerecord (>= 5.2)
       activesupport (>= 5.2)
     polyglot (0.3.5)
@@ -780,7 +779,7 @@ GEM
     redcarpet (3.5.1)
     redis (4.5.1)
     regexp_parser (2.2.0)
-    request_store (1.5.0)
+    request_store (1.5.1)
       rack (>= 1.4)
     responders (3.0.1)
       actionpack (>= 5.0)
@@ -894,7 +893,7 @@ GEM
       babel-source (>= 5.8.11)
       babel-transpiler
       sprockets (>= 3.0.0)
-    sprockets-rails (3.4.1)
+    sprockets-rails (3.4.2)
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
@@ -906,7 +905,7 @@ GEM
     temple (0.8.2)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
-    thor (1.1.0)
+    thor (1.2.1)
     thread_safe (0.3.6)
     tilt (2.0.10)
     tomlrb (2.0.1)
@@ -970,7 +969,7 @@ DEPENDENCIES
   decidim-dev!
   decidim-espais-estables!
   decidim-home!
-  decidim-idcat_mobil (= 0.0.6)!
+  decidim-idcat_mobil (= 0.0.7)
   decidim-process-extended!
   decidim-regulations!
   decidim-templates!


### PR DESCRIPTION
#### :tophat: What? Why?
Because of an upgrade of `omniauth` library a clash of method names appeared between this library and `omiauth-idcat_mobil`. This PR solves this problem by getting the fix implemented in `omiauth-idcat_mobil`.
