### PR TITLE
Alert in Participatory Processes for proposal component activation

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/CodiTramuntana/decidim
-  revision: 1457d715b003780705b727562e3c328a1e565d5c
+  revision: 8f0d2521a1191d007627af02bad5af2db3645e1a
   branch: release/0.24-stable
   specs:
     decidim (0.24.3)
@@ -263,7 +263,7 @@ PATH
   remote: decidim-process-extended
   specs:
     decidim-process-extended (0.1.0)
-      decidim-core
+      decidim-core (~> 0.24.0)
       rails (>= 5.2, < 6.0.x)
 
 PATH
@@ -395,7 +395,7 @@ GEM
       actionpack (>= 3.0)
       cells (>= 4.1.6, < 5.0.0)
     charlock_holmes (0.7.7)
-    chef-utils (17.8.25)
+    chef-utils (17.9.52)
       concurrent-ruby
     childprocess (3.0.0)
     chronic (0.10.2)
@@ -453,7 +453,7 @@ GEM
       railties (>= 4.1.0)
       responders
       warden (~> 1.2.3)
-    devise-i18n (1.10.1)
+    devise-i18n (1.10.2)
       devise (>= 4.8.0)
     devise_invitable (1.7.5)
       actionmailer (>= 4.1.0)
@@ -557,7 +557,7 @@ GEM
     graphiql-rails (1.4.11)
       railties
       sprockets-rails
-    graphql (1.13.9)
+    graphql (1.13.10)
     hashdiff (1.0.1)
     hashie (3.6.0)
     highline (2.0.3)
@@ -569,7 +569,7 @@ GEM
     http_parser.rb (0.6.0)
     i18n (1.9.1)
       concurrent-ruby (~> 1.0)
-    i18n-tasks (0.9.35)
+    i18n-tasks (0.9.37)
       activesupport (>= 4.0.2)
       ast (>= 2.1.0)
       erubi
@@ -583,7 +583,7 @@ GEM
       ice_cube (~> 0.16)
     ice_cube (0.16.4)
     ice_nine (0.11.2)
-    image_processing (1.12.1)
+    image_processing (1.12.2)
       mini_magick (>= 4.9.5, < 5)
       ruby-vips (>= 2.0.17, < 3)
     invisible_captcha (0.13.0)
@@ -874,7 +874,7 @@ GEM
     simplecov-cobertura (1.3.1)
       simplecov (~> 0.8)
     simplecov-html (0.12.3)
-    smart_properties (1.16.3)
+    smart_properties (1.17.0)
     social-share-button (1.2.4)
       coffee-rails
     soda-ruby (1.0.1)

--- a/decidim-process-extended/app/overrides/layouts/admin/participatory_process.rb
+++ b/decidim-process-extended/app/overrides/layouts/admin/participatory_process.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+Deface::Override.new(virtual_path: "layouts/decidim/admin/participatory_process",
+                     name: "add_alert_to_participatory_process_layout",
+                     insert_before: "erb[loud]:contains('yield')",
+                     text: "
+                       <%= render partial: 'decidim/participatory_processes/admin/participatory_processes/proposal_component_alert' %>
+                     ")

--- a/decidim-process-extended/app/views/decidim/participatory_processes/admin/participatory_processes/_proposal_component_alert.html.erb
+++ b/decidim-process-extended/app/views/decidim/participatory_processes/admin/participatory_processes/_proposal_component_alert.html.erb
@@ -1,0 +1,22 @@
+<%
+  def proposal_component_published?
+    proposal_component = nil
+
+    if defined?(current_participatory_process)
+      @group = Decidim::ParticipatoryProcessGroup.find(current_participatory_process.decidim_participatory_process_group_id)
+      proposal_component = current_participatory_process.components.find_by(manifest_name: 'proposals')
+    end
+
+    proposal_component.nil? || !proposal_component.published?
+  end
+%>
+
+<% unless request.path.include?('components') %>
+  <% if proposal_component_published? %>
+    <div class="callout alert">
+      <% if translated_attribute(@group.title) == 'Normativa' %>
+        <%= t('decidim.participatory_processes.admin.participatory_processes.proposal_component_alert') %>
+      <% end %>
+    </div>
+  <% end %>
+<% end %>

--- a/decidim-process-extended/app/views/decidim/participatory_processes/admin/participatory_processes/_proposal_component_alert.html.erb
+++ b/decidim-process-extended/app/views/decidim/participatory_processes/admin/participatory_processes/_proposal_component_alert.html.erb
@@ -11,12 +11,10 @@
   end
 %>
 
-<% unless request.path.include?('components') %>
-  <% if proposal_component_published? %>
+<% if proposal_component_published? %>
+  <% if translated_attribute(@group.title) == 'Normativa' %>
     <div class="callout alert">
-      <% if translated_attribute(@group.title) == 'Normativa' %>
-        <%= t('decidim.participatory_processes.admin.participatory_processes.proposal_component_alert') %>
-      <% end %>
+      <%= t('decidim.participatory_processes.admin.participatory_processes.proposal_component_alert') %>
     </div>
   <% end %>
 <% end %>

--- a/decidim-process-extended/config/locales/ca.yml
+++ b/decidim-process-extended/config/locales/ca.yml
@@ -23,6 +23,7 @@ ca:
             select_process_group: Selecciona un àmbit
             title: Informació general
             visbility: Visibilitat
+          proposal_component_alert: Recordeu que heu d'activar el component propostes.
       show:
         area: Departament
         cost: Cost

--- a/decidim-process-extended/config/locales/es.yml
+++ b/decidim-process-extended/config/locales/es.yml
@@ -23,6 +23,7 @@ es:
             select_process_group: Selecciona un ámbito
             title: Información general
             visbility: Visibilidad
+          proposal_component_alert: Recuerda que tienes que activar el componente propuestas.
       show:
         area: Departamento
         cost: Coste

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -4,3 +4,10 @@ require "decidim/core/test/factories"
 require "decidim/participatory_processes/test/factories"
 require "decidim/proposals/test/factories"
 require "decidim/meetings/test/factories"
+
+FactoryBot.define do
+  factory :type, class: "DecidimType" do
+    name { generate_localized_title }
+    organization
+  end
+end

--- a/spec/system/admin/participatory_processes/admin_manages_participatory_processes_spec.rb
+++ b/spec/system/admin/participatory_processes/admin_manages_participatory_processes_spec.rb
@@ -20,6 +20,7 @@ describe "Admin manages participatory processes", type: :system do
       it "show proposal component alert" do
         visit decidim_admin_participatory_processes.participatory_processes_path
         click_link translated(participatory_process.title)
+        expect(page).to have_css(".alert")
         expect(page).to have_text("Recordeu que heu d'activar el component propostes.")
       end
     end
@@ -32,6 +33,7 @@ describe "Admin manages participatory processes", type: :system do
       it "not show proposal component alert" do
         visit decidim_admin_participatory_processes.participatory_processes_path
         click_link translated(participatory_process.title)
+        expect(page).not_to have_css(".alert")
         expect(page).not_to have_text("Recordeu que heu d'activar el component propostes.")
       end
     end

--- a/spec/system/admin/participatory_processes/admin_manages_participatory_processes_spec.rb
+++ b/spec/system/admin/participatory_processes/admin_manages_participatory_processes_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe "Admin manages participatory processes", type: :system do
+  let(:organization) { create(:organization) }
+  let!(:type) { create(:type, organization: organization) }
+  let!(:user) { create :user, :admin, :confirmed, organization: organization }
+
+  let!(:participatory_process_group) { create(:participatory_process_group, organization: organization, title: { en: "Normativa", es: "Normativa", ca: "Normativa" }) }
+  let!(:participatory_process) { create(:participatory_process, organization: organization, decidim_participatory_process_group_id: participatory_process_group.id) }
+
+  before do
+    switch_to_host(organization.host)
+    login_as user, scope: :user
+  end
+
+  describe "when participatory process group is 'Normativa'" do
+    context "and there is not a proposal component" do
+      it "show proposal component alert" do
+        visit decidim_admin_participatory_processes.participatory_processes_path
+        click_link translated(participatory_process.title)
+        expect(page).to have_text("Recordeu que heu d'activar el component propostes.")
+      end
+    end
+
+    context "and there is a proposal component" do
+      let!(:proposal_component) do
+        create(:component, manifest_name: "proposals", participatory_space: participatory_process, published_at: Time.current)
+      end
+
+      it "not show proposal component alert" do
+        visit decidim_admin_participatory_processes.participatory_processes_path
+        click_link translated(participatory_process.title)
+        expect(page).not_to have_text("Recordeu que heu d'activar el component propostes.")
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?
When participatory process is created and the group is "Normativa", then it shows an alert in order to create and publish  the proposal component.

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [x] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)
![Captura de pantalla de 2022-01-31 09-34-29](https://user-images.githubusercontent.com/75725233/151762099-5e09c5ff-1941-4ac2-b64e-83ad7244fbc8.png)


