### PR TITLE
Update decidim-idcat_mobil

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,7 @@ gem "decidim-top_comments", path: "decidim-top_comments"
 gem "decidim-type", path: "decidim-type"
 #### Custom gems and modifications block end ####
 
-gem "decidim-idcat_mobil", "0.0.8"
+gem "decidim-idcat_mobil", "0.0.9"
 gem "decidim-verifications-members_picker", git: "https://github.com/gencat/decidim-verifications-members_picker.git", tag: "0.0.2"
 gem "rails", "5.2.6"
 gem "soda-ruby", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -427,10 +427,10 @@ GEM
     db-query-matchers (0.9.0)
       activesupport (>= 4.0, <= 6.0)
       rspec (~> 3.0)
-    decidim-idcat_mobil (0.0.8)
+    decidim-idcat_mobil (0.0.9)
       decidim (>= 0.20.0)
       decidim-core (>= 0.20.0)
-      omniauth-idcat_mobil (~> 0.2.3)
+      omniauth-idcat_mobil (~> 0.2.4)
     declarative-builder (0.1.0)
       declarative-option (< 0.2.0)
     declarative-option (0.1.0)
@@ -676,7 +676,7 @@ GEM
       oauth2 (~> 1.1)
       omniauth (~> 1.1)
       omniauth-oauth2 (>= 1.6)
-    omniauth-idcat_mobil (0.2.3)
+    omniauth-idcat_mobil (0.2.4)
       omniauth (~> 1.5)
       omniauth-oauth2 (>= 1.4.0, < 2.0)
     omniauth-oauth (1.2.0)
@@ -969,7 +969,7 @@ DEPENDENCIES
   decidim-dev!
   decidim-espais-estables!
   decidim-home!
-  decidim-idcat_mobil (= 0.0.8)
+  decidim-idcat_mobil (= 0.0.9)
   decidim-process-extended!
   decidim-regulations!
   decidim-templates!


### PR DESCRIPTION
#### :tophat: What? Why?
Yet another bug has been found in the idcat mòbil integration. Because of an incorrect log trace, `auth_token.response` was inoked before using the auth_token to perform any request, resulting in a `NoMethodError` error. This PR solves this problem by getting the fix implemented in omiauth-idcat_mobil.