### PR TITLE
Fix TimeZone in sql query

### DIFF
--- a/decidim-regulations/app/services/decidim/regulations/regulation_search.rb
+++ b/decidim-regulations/app/services/decidim/regulations/regulation_search.rb
@@ -17,7 +17,7 @@ module Decidim
         when "upcoming"
           query.upcoming.order(start_date: :asc)
         else # Assume 'all'
-          current_zone = Time.zone.name
+          current_zone = ActiveSupport::TimeZone.find_tzinfo(Time.zone.name).identifier
           query.order(Arel.sql("ABS(start_date - (CURRENT_DATE at time zone '#{current_zone}')::date)"))
         end
       end


### PR DESCRIPTION
#### :tophat: What? Why?
### Error

```
PG::InvalidParameterValue: ERROR:  time zone "Madrid" not recognized
: SELECT "decidim_participatory_processes".* FROM "decidim_participatory_processes" WHERE "decidim_participatory_processes"."decidim_participatory_process_group_id" = $1 AND "decidim_participatory_processes"."decidim_organization_id" = $2 AND "decidim_participatory_processes"."published_at" IS NOT NULL AND "decidim_participatory_processes"."decidim_participatory_process_group_id" = $3 ORDER BY ABS(start_date - (CURRENT_DATE at time zone 'Madrid')::date)
```

The TimeZone has been fixed because when performing the "All" filter in regulations it gave an previous error.


#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)
![Description](URL)
