### PR TITLE
Update Deface hash in pre_footer

### DIFF
--- a/decidim-home/app/overrides/layouts/decidim/_main_footer/pre_footer.html.erb.deface
+++ b/decidim-home/app/overrides/layouts/decidim/_main_footer/pre_footer.html.erb.deface
@@ -1,5 +1,5 @@
 <!-- insert_before ".main-footer"
-      original 'fb29f1dca87f2e7d8c900c7b13df324d267a2a86'
+      original '9a805aee525dd2b188e7b71a4275eb8638aab68a'
  -->
 <section class="footer__subhero extended subhero home-section">
   <div class="row">


### PR DESCRIPTION
#### :tophat: What? Why?
Fix error with a new hash.


```
D, [2022-01-31T11:40:38.183222 #10798] DEBUG -- : [be124875-7e09-49c0-a1eb-a8c4f422ae23] Deface: 1 overrides found for 'layouts/decidim/_main_footer'
D, [2022-01-31T11:40:38.184622 #10798] DEBUG -- : [be124875-7e09-49c0-a1eb-a8c4f422ae23] Deface: 'pre_footer' matched 1 times with '.main-footer'
E, [2022-01-31T11:40:38.185181 #10798] ERROR -- : [be124875-7e09-49c0-a1eb-a8c4f422ae23] Deface: [ERROR] The original source for 'pre_footer' has changed, this override should be reviewed to ensure it's still valid.
```

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)
![Description](URL)
