### PR TITLE
Fix publish alert when Group is nil inside a Component (proposal, blog..)

### DIFF
--- a/decidim-process-extended/app/views/decidim/participatory_processes/admin/participatory_processes/_proposal_component_alert.html.erb
+++ b/decidim-process-extended/app/views/decidim/participatory_processes/admin/participatory_processes/_proposal_component_alert.html.erb
@@ -12,7 +12,7 @@
 %>
 
 <% if proposal_component_published? %>
-  <% if translated_attribute(@group.title) == 'Normativa' %>
+  <% if translated_attribute(@group&.title) == 'Normativa' %>
     <div class="callout alert">
       <%= t('decidim.participatory_processes.admin.participatory_processes.proposal_component_alert') %>
     </div>


### PR DESCRIPTION
#### :tophat: What? Why?
Inside a component, the variable group is nil.

Fixes #282