### PR TITLE
Avoid differences between repository and deployed JS packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18852,8 +18852,6 @@
     },
     "node_modules/webpack-config-utils/node_modules/webpack-combine-loaders": {
       "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/webpack-combine-loaders/-/webpack-combine-loaders-2.0.4.tgz",
-      "integrity": "sha512-5O5PYVE5tZ3I3uUm3QB7niLEJzLketl8hvAcJwa4YmwNWS/vixfVsqhtUaBciP8J4u/GwIHV52d7kkgZJFvDnw==",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -34384,8 +34382,6 @@
         },
         "webpack-combine-loaders": {
           "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/webpack-combine-loaders/-/webpack-combine-loaders-2.0.4.tgz",
-          "integrity": "sha512-5O5PYVE5tZ3I3uUm3QB7niLEJzLketl8hvAcJwa4YmwNWS/vixfVsqhtUaBciP8J4u/GwIHV52d7kkgZJFvDnw==",
           "bundled": true,
           "requires": {
             "qs": "^6.5.2"


### PR DESCRIPTION
#### :tophat: What? Why?
When installing JS packages in the servers npm changes the `package-lock.json` file.
This PR updates it is not changed when deployed.