### PR TITLE
Use same env vars for throtthling than Decidim's

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
-unless %w(development test).include? Rails.env
+unless %w(development).include?(Rails.env)
   require "rack/attack"
 
-  limit= ENV["RACK_ATTACK_THROTTLE_LIMIT"] || 30
-  period= ENV["RACK_ATTACK_THROTTLE_PERIOD"] || 60
-  Rails.logger.info("Configuring Rack::Attack.throttle with limit: #{limit}, period: #{period}")
-  Rack::Attack.throttle("requests by (forwarded) ip", limit: limit.to_i, period: period.to_i) do |request|
+  limit= ENV["DECIDIM_THROTTLING_MAX_REQUESTS"] || 150
+  period= ENV["DECIDIM_THROTTLING_PERIOD"] || 1
+  Rails.logger.info("Configuring Rack::Attack.throttle with limit: #{limit}, period: #{period} minutes")
+  Rack::Attack.throttle("requests by (forwarded) ip", limit: limit.to_i, period: period.to_i.minute) do |request|
     # x_forwarded_for= request.get_header('X-Forwarded-For')
     x_forwarded_for= request.get_header("HTTP_X_FORWARDED_FOR")
     Rails.logger.debug { ">>>>>>>>>>>>>>>>>>>> X-Forwarded-For: #{x_forwarded_for}" }

--- a/spec/requests/rack_attack_spec.rb
+++ b/spec/requests/rack_attack_spec.rb
@@ -1,0 +1,50 @@
+require "rails_helper"
+
+RSpec.describe "Rack::Attack", type: :request do
+  # Include time helpers to allow use to use travel_to
+  # within RSpec
+  include ActiveSupport::Testing::TimeHelpers
+  before do
+    # Enable Rack::Attack for this test
+    ENV["RACK_ATTACK"] = "true"
+    Rack::Attack.enabled = true
+    Rack::Attack.reset!
+  end
+
+  after do
+    # Disable Rack::Attack for future tests so it doesn't
+    # interfere with the rest of our tests
+    Rack::Attack.enabled = false
+  end
+
+  describe "GET homepage" do
+    let!(:organization) do
+      create(
+        :organization,
+        name: "Participa Gencat",
+        default_locale: :ca,
+        available_locales: [:ca, :en, :es],
+        host: "localhost"
+      )
+    end
+
+    # Set the headers, if you'd blocking specific IPs you can change
+    # this programmatically.
+    let(:headers) { { "HTTP_X_FORWARDED_FOR" => "1.2.3.4" } }
+    let(:root_url) { "http://localhost" }
+
+    it "successful for 10 requests, then blocks the user nicely" do
+      30.times do
+        get root_url, params: {}, headers: headers
+        expect(response).to have_http_status(:success)
+      end
+      get root_url, params: {}, headers: headers
+      expect(response.body).to include("Retry later")
+      expect(response).to have_http_status(:too_many_requests)
+      travel_to(10.minutes.from_now) do
+        get root_url, params: {}, headers: headers
+        expect(response).to have_http_status(:success)
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?
Participa already had a RackAttack initializer. This PR reuses Decidim's Rack Attack environment variables for Participa's Rack Attack initializer.

As a plus a test is added to check that the throttling works as expected.