### PR TITLE
Add all idcat_mobil env vars to secrets

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,9 +27,6 @@ gem "decidim-idcat_mobil", "~> 0.2.1"
 gem "decidim-verifications-members_picker", git: "https://github.com/gencat/decidim-verifications-members_picker.git", tag: "0.0.4"
 gem "soda-ruby", require: false
 
-gem "puma", "< 6"
-gem "rack-attack"
-
 gem "figaro", ">= 1.1.1"
 
 gem "daemons"

--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,8 @@ gem "decidim-idcat_mobil", "~> 0.2.1"
 gem "decidim-verifications-members_picker", git: "https://github.com/gencat/decidim-verifications-members_picker.git", tag: "0.0.4"
 gem "soda-ruby", require: false
 
+gem "puma", "< 6"
+
 gem "figaro", ">= 1.1.1"
 
 gem "daemons"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -651,12 +651,12 @@ GEM
     puma (5.6.4)
       nio4r (~> 2.0)
     racc (1.6.0)
-    rack (2.2.4)
+    rack (2.2.6.4)
     rack-attack (6.6.1)
       rack (>= 1.0, < 3)
     rack-cors (1.1.1)
       rack (>= 2.0.0)
-    rack-protection (2.2.2)
+    rack-protection (3.0.5)
       rack
     rack-proxy (0.7.4)
       rack
@@ -906,8 +906,6 @@ DEPENDENCIES
   figaro (>= 1.1.1)
   letter_opener_web
   listen (~> 3.1.0)
-  puma (< 6)
-  rack-attack
   recaptcha
   rspec-rails
   rubocop-faker

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -906,6 +906,7 @@ DEPENDENCIES
   figaro (>= 1.1.1)
   letter_opener_web
   listen (~> 3.1.0)
+  puma (< 6)
   recaptcha
   rspec-rails
   rubocop-faker

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -34,6 +34,10 @@ default: &default
     idcat_mobil:
       enabled: true
       icon_path: media/images/idcat_mobil-icon.svg
+      client_secret: <%= ENV["IDCAT_MOBIL_CLIENT_SECRET"] %>
+      site: <%= ENV["IDCAT_MOBIL_SITE_URL"] %>
+      client_id: <%= ENV["IDCAT_MOBIL_CLIENT_ID"] %>
+
   geocoder:
     api_key: <%= ENV["GEOCODER_LOOKUP_API_KEY"] %>
   soda:


### PR DESCRIPTION
#### :tophat: What? Why?
In order to be sure that `IdCat mobil` initializer is using the correct variables this PR adds all `idcat_mobil` env vars to secrets. This way when not defined in the organization default variables are correctly readed.

#### :pushpin: Related Issues
- Related to https://3.basecamp.com/4186608/buckets/11242950/todos/5800549107

#### :clipboard: Subtasks
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)
![Description](URL)
