### PR TITLE
Raise log level to :info for :preprod env

### DIFF
--- a/config/environments/preprod.rb
+++ b/config/environments/preprod.rb
@@ -43,7 +43,7 @@ Rails.application.configure do
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.
   # fatal, error, warn, info, debug
-  config.log_level = :debug
+  config.log_level = :info
   # config.log_level = :warn
 
   # Prepend all log lines with the following tags.


### PR DESCRIPTION
#### :tophat: What? Why?
Set the log level to :info for the `preprod` environment because log files increase too much unnecessarily.
