### PR TITLE
All processes are always, at least, virtual

### DIFF
--- a/decidim-process-extended/app/serializers/decidim/participatory_processes/participatory_process_serializer.rb
+++ b/decidim-process-extended/app/serializers/decidim/participatory_processes/participatory_process_serializer.rb
@@ -73,10 +73,7 @@ module Decidim
       end
 
       def process_type
-        types = []
-        types << :virtual if proposals.count.positive? || debates.count.positive?
-        types << :presencial if meetings.count.positive?
-        types.size > 1 ? :ambdos : types.first
+        meetings.count.positive? ? :ambdos : :virtual
       end
 
       def duration_days

--- a/decidim-process-extended/app/serializers/decidim/participatory_processes/participatory_process_serializer.rb
+++ b/decidim-process-extended/app/serializers/decidim/participatory_processes/participatory_process_serializer.rb
@@ -5,6 +5,8 @@ module Decidim
     # This class serializes a ParticipatoryProcess so can be exported
     # to CSV, JSON or other formats (check Decidim::Exporters)
     class ParticipatoryProcessSerializer < Decidim::Exporters::Serializer
+      ATTENDING_ORGANIZATIONS_SEPARATOR_REGEXP= Regexp.union([",", ";", " i ", "\r\n", "\r", "\n"])
+
       # Public: Initializes the serializer with a ParticipatoryProcess.
       def initialize(process)
         @process = process
@@ -120,12 +122,10 @@ module Decidim
       def meetings_num_entities
         return 0 if closed_meetings.blank?
 
-        delimiters = [",", ";", " i ", "\r\n", "\r", "\n"]
-        regex = Regexp.union(delimiters)
-        split_string = proc { |m| m.attending_organizations.split(regex) }
+        split_string = proc { |m| m.attending_organizations&.split(ATTENDING_ORGANIZATIONS_SEPARATOR_REGEXP) }
         @meetings_num_entities ||= closed_meetings
                                    .map(&split_string)
-                                   .flatten
+                                   .flatten.compact
                                    .map(&:strip)
                                    .uniq.count
       end


### PR DESCRIPTION
#### :tophat: What? Why?
This PR changes the behavior of the process_type field send to Socrata.
Now all processes are of type virtual. If they have also meetings they will be both, thus of type "ambdos".

