### PR TITLE
Fix space between number and text in li elements in Quill editor

### DIFF
--- a/app/packs/stylesheets/decidim/decidim_application.scss
+++ b/app/packs/stylesheets/decidim/decidim_application.scss
@@ -1111,3 +1111,10 @@ h1.part-primary-font{
 .inline-filters button[data-toggle], .inline-filters .dropdown-pane{
   width: 16rem !important;
 }
+
+// QUILL EDITOR
+
+// Fix space between number and text in li elements
+.ql-editor-display ol li::before {
+  width: auto;
+}


### PR DESCRIPTION
#### :tophat: What? Why?
In lists, number and text are overlapping

![image](https://github.com/gencat/participa/assets/75725233/fbcade84-fc9d-4a08-a9dc-3a7dc2bb032e)

Now, there are not space between number and text in lists.

![image](https://github.com/gencat/participa/assets/75725233/8b658060-2ac5-41fe-8602-6d09c08187d8)

