### PR TITLE
Extract session duration configuration into an env variable

### DIFF
--- a/config/initializers/decidim.rb
+++ b/config/initializers/decidim.rb
@@ -43,7 +43,7 @@ Decidim.configure do |config|
 
   # How long can a user remained logged in before the session expires. Notice that
   # this is also maximum time that user can idle before getting automatically signed out.
-  config.expire_session_after= 48.hours
+  config.expire_session_after= (ENV["EXPIRE_SESSION_AFTER"].presence || 0.5).hours
 end
 
 Decidim.menu :menu do |menu|


### PR DESCRIPTION
#### :tophat: What? Why?
Extract session duration configuration into an `EXPIRE_SESSION_AFTER` environment variable.