### PR TITLE
Fix parsing of EXPIRE_SESSION_AFTER env var

### DIFF
--- a/config/initializers/decidim.rb
+++ b/config/initializers/decidim.rb
@@ -43,7 +43,7 @@ Decidim.configure do |config|
 
   # How long can a user remained logged in before the session expires. Notice that
   # this is also maximum time that user can idle before getting automatically signed out.
-  config.expire_session_after= (ENV["EXPIRE_SESSION_AFTER"].presence || 0.5).hours
+  config.expire_session_after= (ENV["EXPIRE_SESSION_AFTER"].presence.to_i || 0.5).hours
 end
 
 Decidim.menu :menu do |menu|


### PR DESCRIPTION
#### :tophat: What? Why?
As `EXPIRE_SESSION_AFTER` is retrieved as a String from the ENV, it does not support `.hours`. Thus, it must first be parsed into an integer before converting to `.hours`.

#### :pushpin: Related Issues
- Fixes #461 