### PR TITLE
Fix empty EXPIRE_SESSION_AFTER results in no session at all

### DIFF
--- a/config/initializers/decidim.rb
+++ b/config/initializers/decidim.rb
@@ -43,7 +43,7 @@ Decidim.configure do |config|
 
   # How long can a user remained logged in before the session expires. Notice that
   # this is also maximum time that user can idle before getting automatically signed out.
-  config.expire_session_after= (ENV["EXPIRE_SESSION_AFTER"].presence.to_i || 0.5).hours
+  config.expire_session_after= (ENV["EXPIRE_SESSION_AFTER"].presence || 0.5).to_f.hours
 end
 
 Decidim.menu :menu do |menu|


### PR DESCRIPTION
#### :tophat: What? Why?
When EXPIRE_SESSION_AFTER was not set, zero was being taken as default.
This PR fixes this by fixing the logic of the `||` and allowing half hours by parsing to float instead of integer.

#### :pushpin: Related Issues
- Fixes https://github.com/gencat/participa/pull/461
