### PR TITLE
Configure RackAttack for IP ranges

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-unless ENV["CDTB_RACK_ATTACK_DISABLED"].to_i.positive? || %w[development test].include?(Rails.env)
+unless ENV["CDTB_RACK_ATTACK_DISABLED"].to_i.positive? || %w(development test).include?(Rails.env)
   require "rack/attack"
 
   def extract_ip(request)
@@ -32,7 +32,8 @@ unless ENV["CDTB_RACK_ATTACK_DISABLED"].to_i.positive? || %w[development test].i
     next if request.path.start_with?("/rails/active_storage")
 
     ip= extract_ip(request)
-    range_32bit= ip.split('.')[0,2]
+    # extract the 32bit range
+    ip.split(".")[0, 2]
   end
 
   if ENV["RACK_ATTACK_BLOCKED_IPS"].present?

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,25 +1,38 @@
 # frozen_string_literal: true
 
-unless %w(development test).include? Rails.env
+unless ENV["CDTB_RACK_ATTACK_DISABLED"].to_i.positive? || %w[development test].include?(Rails.env)
   require "rack/attack"
 
-  limit= ENV["RACK_ATTACK_THROTTLE_LIMIT"] || 30
-  period= ENV["RACK_ATTACK_THROTTLE_PERIOD"] || 60
-  Rails.logger.info("Configuring Rack::Attack.throttle with limit: #{limit}, period: #{period}")
-  Rack::Attack.throttle("requests by (forwarded) ip", limit: limit.to_i, period: period.to_i) do |request|
-    # ignore requests to assets
-    next if request.path.start_with?("/rails/active_storage")
-
-    # x_forwarded_for= request.get_header('X-Forwarded-For')
+  def extract_ip(request)
     x_forwarded_for= request.get_header("HTTP_X_FORWARDED_FOR")
-    Rails.logger.debug { ">>>>>>>>>>>>>>>>>>>> X-Forwarded-For: #{x_forwarded_for}" }
+    Rails.logger.info { ">>>>>>>>>>>>>>>>>>>> X-Forwarded-For: #{x_forwarded_for}" }
     if x_forwarded_for.present?
       ip= x_forwarded_for.split(":").first
-      Rails.logger.info { ">>>>>>>>>>>>>>>>>>>> X-Forwarded-For IP: #{ip}" }
       ip
     else
       request.ip
     end
+  end
+
+  limit= ENV.fetch("RACK_ATTACK_THROTTLE_LIMIT", 30)
+  period= ENV.fetch("RACK_ATTACK_THROTTLE_PERIOD", 60)
+  Rails.logger.info("Configuring Rack::Attack.throttle with limit: #{limit}, period: #{period}")
+  Rack::Attack.throttle("requests by ip", limit: limit.to_i, period: period.to_i) do |request|
+    # ignore requests to assets
+    next if request.path.start_with?("/rails/active_storage")
+
+    extract_ip(request)
+  end
+
+  limit= ENV.fetch("RACK_ATTACK_THROTTLE_RANGE_LIMIT", 10)
+  period= ENV.fetch("RACK_ATTACK_THROTTLE_RANGE_PERIOD", 20)
+  Rails.logger.info("Configuring Rack::Attack.throttle with limits for IP Ranges: #{limit}, period: #{period}")
+  Rack::Attack.throttle("requests by ip range", limit: limit.to_i, period: period.to_i) do |request|
+    # ignore requests to assets
+    next if request.path.start_with?("/rails/active_storage")
+
+    ip= extract_ip(request)
+    range_32bit= ip.split('.')[0,2]
   end
 
   if ENV["RACK_ATTACK_BLOCKED_IPS"].present?


### PR DESCRIPTION
#### :tophat: What? Why?
Bad crawlers use farms to crawl the site without being banned. As these farms use the same IP range, we're banning bad behaved IP ranges.
