### PR TITLE
Update deface originals

### DIFF
--- a/decidim-home/app/overrides/layouts/decidim/_main_footer/pre_footer.html.erb.deface
+++ b/decidim-home/app/overrides/layouts/decidim/_main_footer/pre_footer.html.erb.deface
@@ -1,5 +1,5 @@
 <!-- insert_before ".main-footer"
-      original '45e003ac5969458f067be9d4c851c674cbe7f3d3'
+      original '25277dbf8f6306c2d1703a6fe82abf2be777fc7a'
  -->
 <section class="footer__subhero extended subhero home-section">
   <div class="row">

--- a/decidim-top_comments/app/overrides/decidim/debates/debates/show.html.erb.deface
+++ b/decidim-top_comments/app/overrides/decidim/debates/debates/show.html.erb.deface
@@ -1,6 +1,6 @@
 <!-- insert_after 'erb[loud]:root:last-child'
   virtual_path 'decidim/debates/debates/show'
-  original 'cf2dee11f6fad057c3e2910a487b752770fc8329'
+  original '6f795ebcc7ec98156f02484fd7d1e6db5fc07d75'
 -->
 <div id="most-voted-comments" class="expanded">
   <div class="wrapper wrapper--inner">


### PR DESCRIPTION
#### :tophat: What? Why?
Deface overrides errors:

`
[1;32mDeface:[0m 'pre_footer' matched 1 times with '.main-footer'[1;32mDeface: [ERROR][0m The original source for 'pre_footer' has changed, this override should be reviewed to ensure it's still valid.
`

`E, [2024-11-08T10:56:05.385633 #1190517] ERROR -- : [703b7857-ff29-41f6-9d63-c7736c8ddfad] ESC[1;32mDeface: [ERROR]ESC[0m The original source for 'show' has changed, this override should be reviewed to ensure it's still valid.`


### :camera: Screenshots (optional)
#### Top comments override in debates
![image](https://github.com/user-attachments/assets/bdc81c94-e5b9-4af8-a2f1-425154a90d4d)

#### Footer override

![image](https://github.com/user-attachments/assets/a6fd4001-869b-4868-a7bc-54916234d746)

