### PR TITLE
Fix idcat_mobil entry indentation in secrets.yml

### DIFF
--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -125,7 +125,7 @@ default: &default
       enabled: false
       client_id: <%= ENV["OMNIAUTH_GOOGLE_CLIENT_ID"] %>
       client_secret: <%= ENV["OMNIAUTH_GOOGLE_CLIENT_SECRET"] %>
-  idcat_mobil:
+    idcat_mobil:
       enabled: true
       icon_path: media/images/idcat_mobil-icon.svg
       client_secret: <%= ENV["IDCAT_MOBIL_CLIENT_SECRET"] %>


### PR DESCRIPTION
#### :tophat: What? Why?
During the task of upgrading to Decidim 0.28, the `idcat_mobil` omniauth entry in `config/secrets.yml` was incorrectly indented, preventing the platform to use its configuration from environment variables. This PR fixes that indentation.

#### :pushpin: Related Issues
- Related to #497 

#### Screenshots
![imatge](https://github.com/user-attachments/assets/38983fc8-b52d-44be-ae3f-9935d7269767)
