### PR TITLE
Fix decidim release branch

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@
 source "https://rubygems.org"
 
 ruby RUBY_VERSION
-DECIDIM_VERSION = { git: "https://github.com/CodiTramuntana/decidim", branch: "release/0.28-stable_decidim_templates" }.freeze
+DECIDIM_VERSION = { git: "https://github.com/CodiTramuntana/decidim", branch: "release/0.28-stable" }.freeze
 
 gem "decidim", DECIDIM_VERSION
 gem "decidim-templates", DECIDIM_VERSION

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/CodiTramuntana/decidim
-  revision: c1e57f5fca7c98507635748e9dde83161b28a76d
-  branch: release/0.28-stable_decidim_templates
+  revision: c5828f2752bdcbfd962f7416d1861dd822a4c16a
+  branch: release/0.28-stable
   specs:
     decidim (0.28.4)
       decidim-accountability (= 0.28.4)
@@ -59,6 +59,7 @@ GIT
       cells-erb (~> 0.1.0)
       cells-rails (~> 0.1.3)
       charlock_holmes (~> 0.7)
+      concurrent-ruby (= 1.2.2)
       date_validator (~> 0.12.0)
       devise (~> 4.7)
       devise-i18n (~> 1.2, < 1.11.1)
@@ -368,7 +369,7 @@ GEM
       logger (~> 1.5)
     chronic (0.10.2)
     commonmarker (0.23.11)
-    concurrent-ruby (1.3.4)
+    concurrent-ruby (1.2.2)
     crack (1.0.0)
       bigdecimal
       rexml
@@ -499,7 +500,7 @@ GEM
       activesupport (>= 2)
       nokogiri (>= 1.4)
     htmlentities (4.3.4)
-    i18n (1.14.6)
+    i18n (1.14.7)
       concurrent-ruby (~> 1.0)
     i18n-tasks (1.0.14)
       activesupport (>= 4.0.2)
@@ -536,9 +537,10 @@ GEM
       activerecord
       kaminari-core (= 1.2.2)
     kaminari-core (1.2.2)
-    launchy (3.0.1)
+    launchy (3.1.0)
       addressable (~> 2.8)
       childprocess (~> 5.0)
+      logger (~> 1.6)
     letter_opener (1.10.0)
       launchy (>= 2.2, < 4)
     letter_opener_web (3.0.0)
@@ -549,7 +551,7 @@ GEM
     listen (3.9.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
-    logger (1.6.4)
+    logger (1.6.5)
     loofah (2.24.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
@@ -608,8 +610,8 @@ GEM
       rack-protection
     omniauth-facebook (5.0.0)
       omniauth-oauth2 (~> 1.2)
-    omniauth-google-oauth2 (1.2.0)
-      jwt (>= 2.9)
+    omniauth-google-oauth2 (1.2.1)
+      jwt (>= 2.9.2)
       oauth2 (~> 2.0)
       omniauth (~> 2.0)
       omniauth-oauth2 (~> 1.8)
@@ -636,9 +638,9 @@ GEM
       activerecord (>= 5.2)
       request_store (~> 1.1)
     parallel (1.26.3)
-    parallel_tests (4.8.0)
+    parallel_tests (4.9.0)
       parallel
-    parser (3.3.6.0)
+    parser (3.3.7.0)
       ast (~> 2.4.1)
       racc
     pg (1.4.6)
@@ -716,7 +718,7 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
       ffi (~> 1.0)
-    recaptcha (5.18.0)
+    recaptcha (5.19.0)
     redcarpet (3.6.0)
     redis (4.8.1)
     regexp_parser (2.10.0)
@@ -800,7 +802,7 @@ GEM
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
-    selenium-webdriver (4.27.0)
+    selenium-webdriver (4.28.0)
       base64 (~> 0.2)
       logger (~> 1.4)
       rexml (~> 3.2, >= 3.2.5)
@@ -848,7 +850,7 @@ GEM
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
     thor (1.3.2)
-    tilt (2.5.0)
+    tilt (2.6.0)
     timeout (0.4.3)
     trailblazer-option (0.1.2)
     tzinfo (2.0.6)


### PR DESCRIPTION
#### :tophat: What? Why?
In this PR, a custom branch for decidim is changed with the last release/0.28-stable branch.


