### PR TITLE
Modify values for highlighted_regulations on home config admin panel

### DIFF
--- a/decidim-regulations/app/cells/decidim/regulations/content_blocks/highlighted_regulations_cell.rb
+++ b/decidim-regulations/app/cells/decidim/regulations/content_blocks/highlighted_regulations_cell.rb
@@ -36,7 +36,7 @@ module Decidim
             .visible_for(current_user)
             .where("DATE(published_at) > '1990/01/01'")
             .order(published_at: :desc)
-            .limit(8)
+            .limit(max_results)
         end
       end
     end

--- a/decidim-regulations/app/cells/decidim/regulations/content_blocks/highlighted_regulations_settings_form/show.erb
+++ b/decidim-regulations/app/cells/decidim/regulations/content_blocks/highlighted_regulations_settings_form/show.erb
@@ -1,3 +1,3 @@
 <% form.fields_for :settings, form.object.settings do |settings_fields| %>
-  <%= settings_fields.select :max_results, [4, 8, 12], prompt: "", label: label %>
+  <%= settings_fields.select :max_results, [6, 9, 12], prompt: "", label: label %>
 <% end %>

--- a/decidim-regulations/lib/decidim/regulations/engine.rb
+++ b/decidim-regulations/lib/decidim/regulations/engine.rb
@@ -60,7 +60,7 @@ module Decidim
           content_block.settings_form_cell = "decidim/regulations/content_blocks/highlighted_regulations_settings_form"
 
           content_block.settings do |settings|
-            settings.attribute :max_results, type: :integer, default: 4
+            settings.attribute :max_results, type: :integer, default: 6
           end
         end
       end


### PR DESCRIPTION
#### :tophat: What? Why?
Modify value for highlighted regulations on home config admin panel to allow select multiple of 3 values on selector.
Also, the default value has to be 6 instead of 4 or 8.
Fix the value limit for elements to show on home highlighted regulations to get the home admin panel configuration.

#### :pushpin: Related Issues
- Related to https://3.basecamp.com/4186608/buckets/11242950/todos/8194747486#__recording_8252489039
- Fixes https://3.basecamp.com/4186608/buckets/11242950/todos/8194747486#__recording_8252489039

#### :clipboard: Subtasks
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)
![image](https://github.com/user-attachments/assets/cd372667-eb5a-448f-a637-3f1cbcc32f91)

