### PR TITLE
Fix upgrade upload-artifact library to avoid deprecation error on test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -110,7 +110,7 @@ jobs:
 
       # Upload screenshots artifact
       - name: Upload screenshots
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: screenshot_artifact


### PR DESCRIPTION
#### :tophat: What? Why?
There's an error on github actions test with upload-artifact version.

#### :pushpin: Related Issues
Review Dependant bot's PR

#### :clipboard: Subtasks
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)
