### PR TITLE
Add ordering regulations documentation on readme

### DIFF
--- a/decidim-regulations/README.md
+++ b/decidim-regulations/README.md
@@ -27,18 +27,5 @@ $ gem install decidim-regulations
 ## Overrides
 To avoid admin users to accidentally delete the process group that defines which Processes should appear into Regulations, there's a decorator for the ParticipatoryProcessGroupsController#destroy method. The decorator is delared at `decidim-regulations/app/decorators/decidim/regulations/admin/avoid_deletion_of_regulations_group.rb` and is prepended to the controller in this module's engine `to_prepare` declaration.
 
-
-## Ordering Regulations in the **Highlighted Regulations** content block:
-Criteria for ordering which processes are displayed and in what order in the "Highlighted Regulations" content block:
-
-1. Participatory process that belongs to the organization
-2. Visible to the user (public/private)
-3. Processes belong to a group marked as "regulations" 
-4. The publication date is later than 01/01/1990
-5. Ordered by publication date from most recent to oldest
-6. Finally, the limit of visible processes configured in the back office is taken into account
-
-Therefore, it does not take into account whether the process is promoted or not, whether it is active or completed, nor the phase dates.
-
 ## License
 The gem is available as open source under the terms of the [MIT License](http://opensource.org/licenses/MIT).

--- a/decidim-regulations/README.md
+++ b/decidim-regulations/README.md
@@ -28,8 +28,8 @@ $ gem install decidim-regulations
 To avoid admin users to accidentally delete the process group that defines which Processes should appear into Regulations, there's a decorator for the ParticipatoryProcessGroupsController#destroy method. The decorator is delared at `decidim-regulations/app/decorators/decidim/regulations/admin/avoid_deletion_of_regulations_group.rb` and is prepended to the controller in this module's engine `to_prepare` declaration.
 
 
-## Ordering Regulations in the **Highlited Regulations** content block:
-Criteria for ordering which processes are displayed and in what order in the "Highlited Regulations" content block:
+## Ordering Regulations in the **Highlighted Regulations** content block:
+Criteria for ordering which processes are displayed and in what order in the "Highlighted Regulations" content block:
 
 1. Participatory process that belongs to the organization
 2. Visible to the user (public/private)

--- a/decidim-regulations/README.md
+++ b/decidim-regulations/README.md
@@ -28,5 +28,17 @@ $ gem install decidim-regulations
 To avoid admin users to accidentally delete the process group that defines which Processes should appear into Regulations, there's a decorator for the ParticipatoryProcessGroupsController#destroy method. The decorator is delared at `decidim-regulations/app/decorators/decidim/regulations/admin/avoid_deletion_of_regulations_group.rb` and is prepended to the controller in this module's engine `to_prepare` declaration.
 
 
+## Ordering Regulations in the **Highlited Regulations** content block:
+Criteria for ordering which processes are displayed and in what order in the "Highlited Regulations" content block:
+
+1. Participatory process that belongs to the organization
+2. Visible to the user (public/private)
+3. Processes belong to a group marked as "regulations" 
+4. The publication date is later than 01/01/1990
+5. Ordered by publication date from most recent to oldest
+6. Finally, the limit of visible processes configured in the back office is taken into account
+
+Therefore, it does not take into account whether the process is promoted or not, whether it is active or completed, nor the phase dates.
+
 ## License
 The gem is available as open source under the terms of the [MIT License](http://opensource.org/licenses/MIT).

--- a/decidim-regulations/README.md
+++ b/decidim-regulations/README.md
@@ -27,5 +27,6 @@ $ gem install decidim-regulations
 ## Overrides
 To avoid admin users to accidentally delete the process group that defines which Processes should appear into Regulations, there's a decorator for the ParticipatoryProcessGroupsController#destroy method. The decorator is delared at `decidim-regulations/app/decorators/decidim/regulations/admin/avoid_deletion_of_regulations_group.rb` and is prepended to the controller in this module's engine `to_prepare` declaration.
 
+
 ## License
 The gem is available as open source under the terms of the [MIT License](http://opensource.org/licenses/MIT).

--- a/decidim-regulations/app/cells/decidim/regulations/content_blocks/highlighted_regulations_cell.rb
+++ b/decidim-regulations/app/cells/decidim/regulations/content_blocks/highlighted_regulations_cell.rb
@@ -4,6 +4,18 @@ module Decidim
   module Regulations
     module ContentBlocks
       class HighlightedRegulationsCell < Decidim::ContentBlocks::HighlightedParticipatorySpacesCell
+        # ## Ordering Regulations in the **Highlighted Regulations** content block:
+        # Criteria for ordering which processes are displayed and in what order in the "Highlighted Regulations" content block:
+        # 
+        # 1. Participatory process that belongs to the organization
+        # 2. Visible to the user (public/private)
+        # 3. Processes belong to a group marked as "regulations" 
+        # 4. The publication date is later than 01/01/1990
+        # 5. Ordered by publication date from most recent to oldest
+        # 6. Finally, the limit of visible processes configured in the back office is taken into account
+        # 
+        # Therefore, it does not take into account whether the process is promoted or not, whether it is active or completed, nor the phase dates.
+
         delegate :current_user, to: :controller
 
         def highlighted_spaces

--- a/decidim-regulations/app/cells/decidim/regulations/content_blocks/highlighted_regulations_cell.rb
+++ b/decidim-regulations/app/cells/decidim/regulations/content_blocks/highlighted_regulations_cell.rb
@@ -6,14 +6,14 @@ module Decidim
       class HighlightedRegulationsCell < Decidim::ContentBlocks::HighlightedParticipatorySpacesCell
         # ## Ordering Regulations in the **Highlighted Regulations** content block:
         # Criteria for ordering which processes are displayed and in what order in the "Highlighted Regulations" content block:
-        # 
+        #
         # 1. Participatory process that belongs to the organization
         # 2. Visible to the user (public/private)
-        # 3. Processes belong to a group marked as "regulations" 
+        # 3. Processes belong to a group marked as "regulations"
         # 4. The publication date is later than 01/01/1990
         # 5. Ordered by publication date from most recent to oldest
         # 6. Finally, the limit of visible processes configured in the back office is taken into account
-        # 
+        #
         # Therefore, it does not take into account whether the process is promoted or not, whether it is active or completed, nor the phase dates.
 
         delegate :current_user, to: :controller


### PR DESCRIPTION
#### :tophat: What? Why?
Add a documentation of how the regulations are ordered in highlighted content block

#### :pushpin: Related Issues
- Related to https://3.basecamp.com/4186608/buckets/11242950/todos/8194747486

#### :clipboard: Subtasks
- [x] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)
![Description](URL)
