### PR TITLE
Add google tag manager to CSP config

### DIFF
--- a/config/initializers/decidim.rb
+++ b/config/initializers/decidim.rb
@@ -71,7 +71,8 @@ Decidim.configure do |config|
   # Configure CSP for Algolia search for Decidim Finder
   config.content_security_policies_extra = {
     "connect-src" => %w(https://*.algolianet.com https://*.algolianet.net),
-    "img-src" => %w(https://*.algolianet.com https://*.algolianet.net)
+    "img-src" => %w(https://*.algolianet.com https://*.algolianet.net),
+    "script-src" => %w(https://www.googletagmanager.com)
   }
 end
 


### PR DESCRIPTION
#### :tophat: What? Why?
Fix CSP error --> `Content-Security-Policy: The page’s settings blocked a script (script-src-elem) at https://www.googletagmanager.com/gtm.js?id=xxxxx from being executed because it violates the following directive: “script-src 'self' 'unsafe-inline' 'unsafe-eval'”`
