### PR TITLE
Fix all_path method to return regulations index path

### DIFF
--- a/decidim-regulations/app/cells/decidim/regulations/content_blocks/highlighted_regulations_cell.rb
+++ b/decidim-regulations/app/cells/decidim/regulations/content_blocks/highlighted_regulations_cell.rb
@@ -29,7 +29,7 @@ module Decidim
         end
 
         def all_path
-          Decidim::ParticipatoryProcesses::Engine.routes.url_helpers.participatory_processes_path
+          Decidim::Regulations::Engine.routes.url_helpers.regulation_index_path
         end
 
         def max_results


### PR DESCRIPTION
#### :tophat: What? Why?
The link on highlighted regulations section from home page is linked to processes and not regulations

#### :pushpin: Related Issues
- Related to #?
- Fixes https://3.basecamp.com/4186608/buckets/11242950/todos/8375948111

#### :clipboard: Subtasks
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)
![image](https://github.com/user-attachments/assets/10a9e4d6-ae0b-4c2e-b536-c6753a9c3712)

As it can be seen in the capture, now the link on highlighted regulations link to /regulations
