### PR TITLE
Move default branch from master to main

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -3,7 +3,7 @@ name: "[CI] Lint / Lint code"
 on:
   push:
     branches:
-      - master
+      - main
       - release/*
       - "*-stable"
   pull_request:

--- a/.github/workflows/test-process_extended.yml
+++ b/.github/workflows/test-process_extended.yml
@@ -3,7 +3,7 @@ name: "[CI] Process Extended"
 on:
   push:
     branches:
-      - master
+      - main
       - release/*
       - "*-stable"
   pull_request:

--- a/.github/workflows/test-recaptcha.yml
+++ b/.github/workflows/test-recaptcha.yml
@@ -3,7 +3,7 @@ name: "[CI] Recaptcha"
 on:
   push:
     branches:
-      - master
+      - main
       - release/*
       - "*-stable"
   pull_request:

--- a/.github/workflows/test-top_comments.yml
+++ b/.github/workflows/test-top_comments.yml
@@ -3,7 +3,7 @@ name: "[CI] Top Comments"
 on:
   push:
     branches:
-      - master
+      - main
       - release/*
       - "*-stable"
   pull_request:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ name: "[CI] Main Test"
 on:
   push:
     branches:
-      - master
+      - main
       - release/*
       - "*-stable"
   pull_request:

--- a/.github/workflows/validate_migrations.yml
+++ b/.github/workflows/validate_migrations.yml
@@ -3,7 +3,7 @@ name: "[CI] Validate migrations"
 on:
   push:
     branches:
-      - master
+      - main
       - release/*
       - "*-stable"
   pull_request:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@
 - **Changed**: Hide `assembly_type` filter from `Assembly` index page as per request of Product Owner [#87](https://github.com/gencat/participa/pull/87)
 - **Added**: Admin Department Module [#84](https://github.com/gencat/participa/pull/84)
 - **Added**: Feat socrata open data. [#70](https://github.com/gencat/participa/pull/70)
-Review the [README#open-data](https://github.com/gencat/participa/blob/master/README.md#open-data) section to find out the required actions to perform
+Review the [README#open-data](https://github.com/gencat/participa/blob/main/README.md#open-data) section to find out the required actions to perform
 - **Added**: Add new metadata fields to ParticipatoryProcesses. [#69](https://github.com/gencat/participa/pull/69)
 - **Decidim::Verifications::MembersPicker** After installing and activating the verification module, review the [README usage section](https://github.com/gencat/decidim-verifications-members_picker/blob/0.0.2/README.md#usage) to execute the necessary actions
 - **DecidimDepartment, DecidimTheme, DecidimType:** Only for upgrades from 0.18 or earlier versions [#67](https://github.com/gencat/participa/pull/67)

--- a/docs/HOW_TO_UPGRADE.md
+++ b/docs/HOW_TO_UPGRADE.md
@@ -27,7 +27,7 @@ bin/rails db:migrate
   * Decidim::Process::Extended ("decidim-process-extended")
 
 
-4. Go to the changelog of the specific branch you are updating. For example, https://github.com/decidim/decidim/blob/master/CHANGELOG.md. And review each of the new developments introduced, and apply the new changes.
+4. Go to the changelog of the specific branch you are updating. For example, https://github.com/decidim/decidim/blob/main/CHANGELOG.md. And review each of the new developments introduced, and apply the new changes.
    If there are some new locales added or changed, take in mind, that until the locale :oc is added to the Decidim, you must add the new Occitan translations to the application.
 
 5. also, you can make sure new translations are complete for all languages in your application doing this:


### PR DESCRIPTION
#### :tophat: What? Why?
It's already time to use current git standard for default branch, so we move from `master` to `main`.