### PR TITLE
Update CSP settings to allow Google Tag Manager and Piwik domains

### DIFF
--- a/config/initializers/decidim.rb
+++ b/config/initializers/decidim.rb
@@ -84,8 +84,8 @@ Decidim.configure do |config|
   # Configure CSP for Algolia search for Decidim Finder
   config.content_security_policies_extra = {
     "connect-src" => %w(https://*.algolianet.com https://*.algolianet.net),
-    "img-src" => %w(https://*.algolianet.com https://*.algolianet.net),
-    "script-src" => %w(https://www.googletagmanager.com)
+    "img-src" => %w(https://*.algolianet.com https://*.algolianet.net https://www.googletagmanager.com https://gencat.containers.piwik.pro),
+    "script-src" => %w(https://www.googletagmanager.com https://gencat.containers.piwik.pro)
   }
 end
 


### PR DESCRIPTION
#### :tophat: What? Why?
This PR updates the content_security_policies_extra in config/initializers/decidim.rb to include the necessary domains for Google Tag Manager and Piwik to function correctly.

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [x] Another subtask
