### PR TITLE
Do not set empty String instead of nil when translation fail

### DIFF
--- a/lib/participa_gencat/softcatala_translator.rb
+++ b/lib/participa_gencat/softcatala_translator.rb
@@ -27,7 +27,7 @@ module ParticipaGencat
         resource,
         field_name,
         target_locale,
-        translated_text
+        translated_text || ""
       )
     end
 

--- a/spec/lib/participa_gencat/softcatala_translator_spec.rb
+++ b/spec/lib/participa_gencat/softcatala_translator_spec.rb
@@ -46,5 +46,22 @@ module ParticipaGencat
         subject.translate
       end
     end
+
+    context "when the translation fails" do
+      let(:translated_value) { nil }
+
+      it "schedules a job to save an empty string" do
+        expect(::Decidim::MachineTranslationSaveJob)
+          .to receive(:perform_later)
+          .with(
+            resource,
+            field_name,
+            target_locale,
+            ""
+          )
+
+        subject.translate
+      end
+    end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
When a translation fails, it is now set as `nil` but  this causes problems in other parts of the system that expect them to be, at least, an empty string.

Now if the translation client returns nil, the attribute is set to an empty string.

#### :clipboard: Subtasks
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [x] Add tests
- [ ] Another subtask

