### PR TITLE
Fix alt text for FEDER image in footer override

### DIFF
--- a/decidim-home/app/overrides/layouts/decidim/footer/_main/feder_footer.html.erb.deface
+++ b/decidim-home/app/overrides/layouts/decidim/footer/_main/feder_footer.html.erb.deface
@@ -9,7 +9,7 @@
 
     <div class="lg:w-1/6">
       <%= link_to "http://www.accio.gencat.cat/ca/accio/agencia/feder/", target: "_blank", class: "block logo" do %>
-        <%= image_pack_tag "media/images/feder.png", alt: "FEDER" %>
+        <%= image_pack_tag "media/images/feder.png", alt: "Unió Europea. Fons Europeu de Desenvolupament Regional" %>
       <% end %>
     </div>
   </div>


### PR DESCRIPTION
#### :tophat: What? Why?
Updated the `alt` attribute of the FEDER image in the footer override to reflect the actual text in the image:  
"Unió Europea. Fons Europeu de Desenvolupament Regional".

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)
![image](https://github.com/user-attachments/assets/ee0d0b75-be80-4a60-a8e7-1e2fbcb00ef3)

