### PR TITLE
Add participatory space to meeting card

### DIFF
--- a/app/overrides/decidim/meetings/meeting_card_metadata_override.rb
+++ b/app/overrides/decidim/meetings/meeting_card_metadata_override.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Meetings
+    module MeetingCardMetadataCellExtension
+      extend ActiveSupport::Concern
+
+      private
+
+      def meeting_items
+        items = super
+        items << participatory_process_item if show_participatory_process?
+        items
+      end
+
+      def participatory_process_item
+        {
+          text: translated_attribute(meeting.component.participatory_space.title),
+          icon: "government-line"
+        }
+      end
+
+      def show_participatory_process?
+        current_participatory_space = try(:current_participatory_space)
+
+        current_participatory_space.nil? ||
+          current_participatory_space != meeting.component.participatory_space
+      end
+    end
+  end
+end
+
+Decidim::Meetings::MeetingCardMetadataCell.prepend(
+  Decidim::Meetings::MeetingCardMetadataCellExtension
+)


### PR DESCRIPTION
#### :tophat: Include participatory process name into meeting card


#### :pushpin: Related Issues
- Related to https://3.basecamp.com/4186608/buckets/11242950/todos/8797217012
- Fixes #?

#### :clipboard: Subtasks
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)
<img width="1759" height="1186" alt="image" src="https://github.com/user-attachments/assets/6e978b50-ee6c-4a50-addd-b5ec8896f2ed" />

![Description](URL)
