### PR TITLE
Fix raw hash on old processes

### DIFF
--- a/db/migrate/20260316160034_backfill_has_summary_record_default.rb
+++ b/db/migrate/20260316160034_backfill_has_summary_record_default.rb
@@ -1,0 +1,11 @@
+class BackfillHasSummaryRecordDefault < ActiveRecord::Migration[7.0]
+  def change
+    execute <<-SQL.squish
+      UPDATE decidim_participatory_processes
+      SET has_summary_record = false
+      WHERE has_summary_record IS NULL
+    SQL
+
+    change_column_null :decidim_participatory_processes, :has_summary_record, false, false
+  end
+end

--- a/db/migrate/20260316160034_backfill_has_summary_record_default.rb
+++ b/db/migrate/20260316160034_backfill_has_summary_record_default.rb
@@ -1,11 +1,6 @@
 class BackfillHasSummaryRecordDefault < ActiveRecord::Migration[7.0]
   def change
-    execute <<-SQL.squish
-      UPDATE decidim_participatory_processes
-      SET has_summary_record = false
-      WHERE has_summary_record IS NULL
-    SQL
-
+    change_column_default :decidim_participatory_processes, :has_summary_record, from: nil, to: false
     change_column_null :decidim_participatory_processes, :has_summary_record, false, false
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2026_01_20_111521) do
+ActiveRecord::Schema[7.0].define(version: 2026_03_16_160034) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "ltree"
   enable_extension "pg_trgm"
@@ -1161,7 +1161,7 @@ ActiveRecord::Schema[7.0].define(version: 2026_01_20_111521) do
     t.boolean "private_space", default: false
     t.bigint "decidim_area_id"
     t.decimal "cost"
-    t.boolean "has_summary_record"
+    t.boolean "has_summary_record", null: false
     t.string "facilitators"
     t.string "promoting_unit"
     t.bigint "decidim_scope_type_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1161,7 +1161,7 @@ ActiveRecord::Schema[7.0].define(version: 2026_03_16_160034) do
     t.boolean "private_space", default: false
     t.bigint "decidim_area_id"
     t.decimal "cost"
-    t.boolean "has_summary_record", null: false
+    t.boolean "has_summary_record", default: false, null: false
     t.string "facilitators"
     t.string "promoting_unit"
     t.bigint "decidim_scope_type_id"


### PR DESCRIPTION
#### :tophat: What? Why?
Backfill has_summary_record NULL values to false and add NOT NULL constraint to prevent old processes from rendering the raw translation hash {:false=>"No", :true=>"Si"} in the public view.

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)
![Description](URL)
