### PR TITLE
Patch wicked_pdf crash without Sprockets

### DIFF
--- a/config/initializers/wicked_pdf_sprockets_fix.rb
+++ b/config/initializers/wicked_pdf_sprockets_fix.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# Fix for wicked_pdf 2.8.x when Sprockets is not available (app uses Shakapacker).
+# The find_asset method falls through to SprocketsEnvironment which references
+# the Sprockets constant that doesn't exist, causing:
+#   uninitialized constant WickedPdf::WickedPdfHelper::Assets::SprocketsEnvironment::Sprockets
+#
+# See: https://github.com/mileszs/wicked_pdf/issues/1102
+# See: https://github.com/decidim/decidim/issues/14764
+#
+# This was fixed upstream in decidim >= 0.30 by removing wicked_pdf entirely.
+
+Rails.application.config.after_initialize do
+  WickedPdf::WickedPdfHelper::Assets::SprocketsEnvironment.class_eval do
+    def self.instance
+      return nil unless defined?(::Sprockets)
+
+      @instance ||= ::Sprockets::Railtie.build_environment(Rails.application)
+    end
+
+    def self.find_asset(*args)
+      return nil unless instance
+
+      instance.find_asset(*args)
+    end
+  end
+end

--- a/config/initializers/wicked_pdf_sprockets_fix.rb
+++ b/config/initializers/wicked_pdf_sprockets_fix.rb
@@ -13,9 +13,9 @@
 Rails.application.config.after_initialize do
   WickedPdf::WickedPdfHelper::Assets::SprocketsEnvironment.class_eval do
     def self.instance
-      return nil unless defined?(::Sprockets)
+      return nil unless defined?(Sprockets)
 
-      @instance ||= ::Sprockets::Railtie.build_environment(Rails.application)
+      @instance ||= Sprockets::Railtie.build_environment(Rails.application)
     end
 
     def self.find_asset(*args)

--- a/config/initializers/wicked_pdf_sprockets_fix.rb
+++ b/config/initializers/wicked_pdf_sprockets_fix.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# NOTE: This problem does NOT occur in newer versions of Decidim (>= 0.30).
+
 # Fix for wicked_pdf 2.8.x when Sprockets is not available (app uses Shakapacker).
 # The find_asset method falls through to SprocketsEnvironment which references
 # the Sprockets constant that doesn't exist, causing:


### PR DESCRIPTION
#### :tophat: What? Why?
Wicked_pdf 2.8.x falls back to SprocketsEnvironment.find_asset when Rails.application.assets does not respond to find_asset and neither Propshaft nor assets_manifest is available. 
This causes an uninitialized constant error.

Added an initializer that monkey-patches SprocketsEnvironment to return nil safely when Sprockets is not defined, allowing wicked_pdf to continue.
#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)
![Description](URL)
