### PR TITLE
Add Google Maps URL to meetings

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,33 @@ This is the open-source repository for "participa", based on [Decidim](https://g
 - `Decidim::Admin::Extended`, customize admin menu adding custom configurations.
 - `Decidim::Recaptcha`, use recaptcha instead invisible captcha.
 
+## Decidim Core Overrides
+
+Customizations applied on top of Decidim core via decorators (`app/decorators/`) and Deface view overrides (`app/overrides/`).
+
+### Google Maps URL for meetings
+
+Adds an optional **Google Maps URL** field to in-person and hybrid meetings, allowing admins to link participants directly to the meeting location on Google Maps.
+
+**Behavior:**
+- Field is visible only in the **admin** meeting form.
+- Shown/hidden dynamically by the existing meeting-type JavaScript: visible when type is _In-person_ or _Hybrid_, hidden for _Online_.
+- On the **public meeting show page**, the address text becomes a clickable link that opens Google Maps in a new browser tab when a URL is set.
+- The address renders as plain text when no URL is set, or for online meetings.
+
+**Implementation files:**
+
+| File | Purpose |
+|---|---|
+| `db/migrate/20260427100000_add_google_maps_url_to_meetings.rb` | Adds `google_maps_url` column to `decidim_meetings_meetings` |
+| `app/decorators/decidim/meetings/admin/meeting_form_decorator.rb` | Adds `google_maps_url` attribute + URL validation to the admin form |
+| `app/decorators/decidim/meetings/admin/create_meeting_decorator.rb` | Persists `google_maps_url` when creating a meeting |
+| `app/decorators/decidim/meetings/admin/update_meeting_decorator.rb` | Persists `google_maps_url` when updating a meeting |
+| `app/overrides/decidim/meetings/admin/meetings/form_google_maps_url.rb` | Deface override — inserts the field in the admin form view |
+| `app/decorators/decidim/address_cell_decorator.rb` | Decorator — overrides `AddressCell#address` to wrap the address in a Google Maps link |
+| `config/locales/{en,ca,es}_meetings.yml` | Translations (new files) |
+| `config/locales/oc_meetings.yml` | Occitan translations (updated) |
+
 ## Deploying the app
 
 An opinionated guide to deploy this app to Heroku can be found at [https://github.com/codegram/decidim-deploy-heroku](https://github.com/codegram/decidim-deploy-heroku).

--- a/app/decorators/decidim/address_cell_decorator.rb
+++ b/app/decorators/decidim/address_cell_decorator.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+# Makes the address text a clickable Google Maps link when the resource has a
+# google_maps_url set. Applies to any resource using the decidim/address cell,
+# guarded by respond_to? so non-meeting resources are unaffected.
+# Overrides Decidim::AddressCell#address.
+# Original: decidim_fork/decidim-core/app/cells/decidim/address_cell.rb
+module Decidim::AddressCellDecorator
+  def self.decorate
+    Decidim::AddressCell.class_eval do
+      alias_method :address_without_google_maps_url, :address
+
+      def address
+        text = address_without_google_maps_url
+        return text unless model.respond_to?(:google_maps_url) && model.google_maps_url.present?
+
+        url = ERB::Util.html_escape(model.google_maps_url)
+        "<a class=\"button__text-secondary\" href=\"#{url}\" target=\"_blank\" rel=\"noopener noreferrer\" data-external-link=\"false\">#{text}</a>".html_safe
+      end
+    end
+  end
+end
+
+Decidim::AddressCellDecorator.decorate

--- a/app/decorators/decidim/meetings/admin/create_meeting_decorator.rb
+++ b/app/decorators/decidim/meetings/admin/create_meeting_decorator.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+# Adds google_maps_url to the attributes persisted when creating a meeting.
+# Overrides Decidim::Meetings::Admin::CreateMeeting.
+# Original: decidim_fork/decidim-meetings/app/commands/decidim/meetings/admin/create_meeting.rb
+module Decidim::Meetings::Admin::CreateMeetingDecorator
+  def self.decorate
+    Decidim::Meetings::Admin::CreateMeeting.class_eval do
+      alias_method :original_attributes, :attributes
+
+      def attributes
+        original_attributes.merge(google_maps_url: form.google_maps_url)
+      end
+    end
+  end
+end
+
+Decidim::Meetings::Admin::CreateMeetingDecorator.decorate

--- a/app/decorators/decidim/meetings/admin/meeting_form_decorator.rb
+++ b/app/decorators/decidim/meetings/admin/meeting_form_decorator.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+# Adds the google_maps_url attribute and URL validation to the admin meeting form.
+# Overrides Decidim::Meetings::Admin::MeetingForm.
+# Original: decidim_fork/decidim-meetings/app/forms/decidim/meetings/admin/meeting_form.rb
+module Decidim::Meetings::Admin::MeetingFormDecorator
+  def self.decorate
+    Decidim::Meetings::Admin::MeetingForm.class_eval do
+      attribute :google_maps_url, String
+
+      validates :google_maps_url, url: true, allow_blank: true,
+                                  if: ->(form) { form.in_person_meeting? || form.hybrid_meeting? }
+    end
+  end
+end
+
+Decidim::Meetings::Admin::MeetingFormDecorator.decorate

--- a/app/decorators/decidim/meetings/admin/meeting_form_decorator.rb
+++ b/app/decorators/decidim/meetings/admin/meeting_form_decorator.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 # Adds the google_maps_url attribute and URL validation to the admin meeting form.
+# Only URLs from allowed Google Maps domains are accepted:
+#   https://www.google.com/maps/
+#   https://maps.app.goo.gl
 # Overrides Decidim::Meetings::Admin::MeetingForm.
 # Original: decidim_fork/decidim-meetings/app/forms/decidim/meetings/admin/meeting_form.rb
 module Decidim::Meetings::Admin::MeetingFormDecorator
@@ -10,6 +13,14 @@ module Decidim::Meetings::Admin::MeetingFormDecorator
 
       validates :google_maps_url, url: true, allow_blank: true,
                                   if: ->(form) { form.in_person_meeting? || form.hybrid_meeting? }
+
+      validate :google_maps_url_domain, if: -> { google_maps_url.present? && (in_person_meeting? || hybrid_meeting?) }
+
+      def google_maps_url_domain
+        return if google_maps_url.start_with?("https://www.google.com/maps/", "https://maps.app.goo.gl")
+
+        errors.add(:google_maps_url, :invalid_google_maps_domain)
+      end
     end
   end
 end

--- a/app/decorators/decidim/meetings/admin/update_meeting_decorator.rb
+++ b/app/decorators/decidim/meetings/admin/update_meeting_decorator.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+# Adds google_maps_url to the attributes persisted when updating a meeting.
+# Overrides Decidim::Meetings::Admin::UpdateMeeting.
+# Original: decidim_fork/decidim-meetings/app/commands/decidim/meetings/admin/update_meeting.rb
+module Decidim::Meetings::Admin::UpdateMeetingDecorator
+  def self.decorate
+    Decidim::Meetings::Admin::UpdateMeeting.class_eval do
+      alias_method :original_attributes, :attributes
+
+      def attributes
+        original_attributes.merge(google_maps_url: form.google_maps_url)
+      end
+    end
+  end
+end
+
+Decidim::Meetings::Admin::UpdateMeetingDecorator.decorate

--- a/app/overrides/decidim/meetings/admin/meetings/form_google_maps_url.rb
+++ b/app/overrides/decidim/meetings/admin/meetings/form_google_maps_url.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+# Inserts a Google Maps URL field in the admin meeting form,
+# visible only for in-person and hybrid meeting types.
+# Overrides view: decidim/meetings/admin/meetings/_form
+# Original: decidim_fork/decidim-meetings/app/views/decidim/meetings/admin/meetings/_form.html.erb
+Deface::Override.new(
+  virtual_path: "decidim/meetings/admin/meetings/_form",
+  name: "meeting_form_google_maps_url",
+  insert_before: "div.row.column:not(.iframe-fields--embed-type)[data-meeting-type='online']",
+  text: <<~HTML
+    <div class="row column" data-meeting-type="in_person">
+      <%= form.text_field :google_maps_url, help_text: t(".google_maps_url_help") %>
+    </div>
+  HTML
+)

--- a/config/locales/ca_meetings.yml
+++ b/config/locales/ca_meetings.yml
@@ -1,0 +1,12 @@
+---
+ca:
+  activemodel:
+    attributes:
+      meeting:
+        google_maps_url: URL de Google Maps
+  decidim:
+    meetings:
+      admin:
+        meetings:
+          form:
+            google_maps_url_help: "Afegeix un enllaç de Google Maps amb l'adreça de la trobada per facilitar a les usuàries arribar al lloc."

--- a/config/locales/ca_meetings.yml
+++ b/config/locales/ca_meetings.yml
@@ -4,6 +4,9 @@ ca:
     attributes:
       meeting:
         google_maps_url: URL de Google Maps
+    errors:
+      messages:
+        invalid_google_maps_domain: "ha de ser un URL vàlid de Google Maps (google.com/maps o maps.app.goo.gl)"
   decidim:
     meetings:
       admin:

--- a/config/locales/en_meetings.yml
+++ b/config/locales/en_meetings.yml
@@ -4,6 +4,9 @@ en:
     attributes:
       meeting:
         google_maps_url: Google Maps URL
+    errors:
+      messages:
+        invalid_google_maps_domain: "must be a valid Google Maps URL (google.com/maps or maps.app.goo.gl)"
   decidim:
     meetings:
       admin:

--- a/config/locales/en_meetings.yml
+++ b/config/locales/en_meetings.yml
@@ -1,0 +1,12 @@
+---
+en:
+  activemodel:
+    attributes:
+      meeting:
+        google_maps_url: Google Maps URL
+  decidim:
+    meetings:
+      admin:
+        meetings:
+          form:
+            google_maps_url_help: "Add a Google Maps link with the meeting address to help participants get to the venue."

--- a/config/locales/es_meetings.yml
+++ b/config/locales/es_meetings.yml
@@ -1,0 +1,12 @@
+---
+es:
+  activemodel:
+    attributes:
+      meeting:
+        google_maps_url: URL de Google Maps
+  decidim:
+    meetings:
+      admin:
+        meetings:
+          form:
+            google_maps_url_help: "Añade un enlace de Google Maps con la dirección del encuentro para facilitar a las usuarias llegar al lugar."

--- a/config/locales/es_meetings.yml
+++ b/config/locales/es_meetings.yml
@@ -4,6 +4,9 @@ es:
     attributes:
       meeting:
         google_maps_url: URL de Google Maps
+    errors:
+      messages:
+        invalid_google_maps_domain: "debe ser una URL válida de Google Maps (google.com/maps o maps.app.goo.gl)"
   decidim:
     meetings:
       admin:

--- a/config/locales/oc_meetings.yml
+++ b/config/locales/oc_meetings.yml
@@ -35,6 +35,8 @@ oc:
         video_url: URL del vídeo
         visible: És visible
     errors:
+      messages:
+        invalid_google_maps_domain: "deu èsser un URL valid de Google Maps (google.com/maps o maps.app.goo.gl)"
       models:
         meeting_agenda:
           attributes:

--- a/config/locales/oc_meetings.yml
+++ b/config/locales/oc_meetings.yml
@@ -19,6 +19,7 @@ oc:
         description: Descripció
         end_time: Hora de finalització
         location: Ubicació
+        google_maps_url: URL de Google Maps
         location_hints: Detalls d'ubicació
         organizer_id: Organitzador
         private_meeting: Trobada privada
@@ -248,6 +249,7 @@ oc:
           form:
             address_help: 'Adreça: que farà servir per Geocoder per a trobar la localització'
             location_help: 'Localització: missatge dirigit a les participants indicant el lloc on trobar-se'
+            google_maps_url_help: "Afortís un ligam de Google Maps amb l'adreça de la trobada per facilitar a las utilizadoras d'arribar al luòc."
             location_hints_help: 'Ajuda de localització: informació addicional. Per exemple: la planta de l''edifici'
             select_organizer: Selecciona l'organitzadora
           index:

--- a/db/migrate/20260427100000_add_google_maps_url_to_meetings.rb
+++ b/db/migrate/20260427100000_add_google_maps_url_to_meetings.rb
@@ -2,6 +2,6 @@
 
 class AddGoogleMapsUrlToMeetings < ActiveRecord::Migration[7.0]
   def change
-    add_column :decidim_meetings_meetings, :google_maps_url, :string
+    add_column :decidim_meetings_meetings, :google_maps_url, :text
   end
 end

--- a/db/migrate/20260427100000_add_google_maps_url_to_meetings.rb
+++ b/db/migrate/20260427100000_add_google_maps_url_to_meetings.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddGoogleMapsUrlToMeetings < ActiveRecord::Migration[7.0]
+  def change
+    add_column :decidim_meetings_meetings, :google_maps_url, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2026_03_16_160034) do
+ActiveRecord::Schema[7.0].define(version: 2026_04_27_100000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "ltree"
   enable_extension "pg_trgm"
@@ -851,6 +851,7 @@ ActiveRecord::Schema[7.0].define(version: 2026_03_16_160034) do
     t.integer "type_of_meeting", default: 0, null: false
     t.integer "registration_type", default: 0, null: false
     t.datetime "withdrawn_at", precision: nil
+    t.string "google_maps_url"
     t.index ["decidim_author_id", "decidim_author_type"], name: "index_decidim_meetings_meetings_on_author"
     t.index ["decidim_author_id"], name: "index_decidim_meetings_meetings_on_decidim_author_id"
     t.index ["decidim_component_id"], name: "index_decidim_meetings_meetings_on_decidim_component_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -851,7 +851,7 @@ ActiveRecord::Schema[7.0].define(version: 2026_04_27_100000) do
     t.integer "type_of_meeting", default: 0, null: false
     t.integer "registration_type", default: 0, null: false
     t.datetime "withdrawn_at", precision: nil
-    t.string "google_maps_url"
+    t.text "google_maps_url"
     t.index ["decidim_author_id", "decidim_author_type"], name: "index_decidim_meetings_meetings_on_author"
     t.index ["decidim_author_id"], name: "index_decidim_meetings_meetings_on_decidim_author_id"
     t.index ["decidim_component_id"], name: "index_decidim_meetings_meetings_on_decidim_component_id"

--- a/spec/system/admin/meeting_google_maps_url_spec.rb
+++ b/spec/system/admin/meeting_google_maps_url_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe "Admin Google Maps URL field for meetings", type: :system do
+  let!(:organization) { create(:organization) }
+  let!(:user) { create(:user, :admin, :confirmed, organization:) }
+  let!(:participatory_process) { create(:participatory_process, :published, :with_steps, organization:) }
+  let!(:meetings_component) { create(:meeting_component, :published, participatory_space: participatory_process) }
+  let(:google_maps_url) { "https://maps.google.com/maps?q=test+location" }
+
+  before do
+    switch_to_host(organization.host)
+    login_as user, scope: :user
+  end
+
+  def admin_edit_meeting_path(meeting)
+    "/admin/participatory_processes/#{participatory_process.slug}/components/#{meetings_component.id}/manage/meetings/#{meeting.id}/edit"
+  end
+
+  context "when editing an in_person meeting" do
+    let!(:meeting) { create(:meeting, :published, :in_person, component: meetings_component) }
+
+    before { visit admin_edit_meeting_path(meeting) }
+
+    it "shows the google_maps_url field" do
+      expect(page).to have_css("input[name='meeting[google_maps_url]']", visible: :visible)
+    end
+
+    it "saves a valid google_maps_url" do
+      fill_in "meeting[google_maps_url]", with: google_maps_url
+      find("button[name='commit']").click
+      expect(page).to have_admin_callout("successfully")
+      expect(meeting.reload.google_maps_url).to eq(google_maps_url)
+    end
+
+    it "shows a validation error for an invalid URL" do
+      fill_in "meeting[google_maps_url]", with: "not-a-url"
+      find("button[name='commit']").click
+      expect(page).to have_admin_callout("problem")
+    end
+
+    it "allows saving with a blank google_maps_url" do
+      fill_in "meeting[google_maps_url]", with: ""
+      find("button[name='commit']").click
+      expect(page).to have_admin_callout("successfully")
+      expect(meeting.reload.google_maps_url).to be_blank
+    end
+  end
+
+  context "when editing an online meeting" do
+    let!(:meeting) { create(:meeting, :published, :online, component: meetings_component) }
+
+    before { visit admin_edit_meeting_path(meeting) }
+
+    it "does not show the google_maps_url field" do
+      expect(page).to have_css("input[name='meeting[google_maps_url]']", visible: :hidden)
+    end
+  end
+
+  context "when editing a hybrid meeting" do
+    let!(:meeting) { create(:meeting, :published, :hybrid, component: meetings_component) }
+
+    before { visit admin_edit_meeting_path(meeting) }
+
+    it "shows the google_maps_url field" do
+      expect(page).to have_css("input[name='meeting[google_maps_url]']", visible: :visible)
+    end
+
+    it "saves a valid google_maps_url for a hybrid meeting" do
+      fill_in "meeting[google_maps_url]", with: google_maps_url
+      find("button[name='commit']").click
+      expect(page).to have_admin_callout("successfully")
+      expect(meeting.reload.google_maps_url).to eq(google_maps_url)
+    end
+  end
+end

--- a/spec/system/admin/meeting_google_maps_url_spec.rb
+++ b/spec/system/admin/meeting_google_maps_url_spec.rb
@@ -37,7 +37,7 @@ describe "Admin Google Maps URL field for meetings", type: :system do
     it "shows a validation error for an invalid URL" do
       fill_in "meeting[google_maps_url]", with: "not-a-url"
       find("button[name='commit']").click
-      expect(page).to have_admin_callout("problem")
+      expect(page).to have_admin_callout("problem updating this meeting")
     end
 
     it "allows saving with a blank google_maps_url" do

--- a/spec/system/admin/meeting_google_maps_url_spec.rb
+++ b/spec/system/admin/meeting_google_maps_url_spec.rb
@@ -7,7 +7,7 @@ describe "Admin Google Maps URL field for meetings", type: :system do
   let!(:user) { create(:user, :admin, :confirmed, organization:) }
   let!(:participatory_process) { create(:participatory_process, :published, :with_steps, organization:) }
   let!(:meetings_component) { create(:meeting_component, :published, participatory_space: participatory_process) }
-  let(:google_maps_url) { "https://maps.google.com/maps?q=test+location" }
+  let(:google_maps_url) { "https://www.google.com/maps/place/test+location" }
 
   before do
     switch_to_host(organization.host)
@@ -36,6 +36,12 @@ describe "Admin Google Maps URL field for meetings", type: :system do
 
     it "shows a validation error for an invalid URL" do
       fill_in "meeting[google_maps_url]", with: "not-a-url"
+      find("button[name='commit']").click
+      expect(page).to have_admin_callout("problem updating this meeting")
+    end
+
+    it "shows a validation error for a URL not from Google Maps" do
+      fill_in "meeting[google_maps_url]", with: "https://example.com/maps/place/test"
       find("button[name='commit']").click
       expect(page).to have_admin_callout("problem updating this meeting")
     end

--- a/spec/system/meeting_google_maps_url_show_spec.rb
+++ b/spec/system/meeting_google_maps_url_show_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe "Google Maps URL on meeting show page", type: :system do
+  let!(:organization) { create(:organization) }
+  let!(:participatory_process) { create(:participatory_process, :published, :with_steps, organization:) }
+  let!(:meetings_component) { create(:meeting_component, :published, participatory_space: participatory_process) }
+  let(:google_maps_url) { "https://maps.google.com/maps?q=Test+Location" }
+
+  before { switch_to_host(organization.host) }
+
+  def meeting_show_path(meeting)
+    "/processes/#{participatory_process.slug}/f/#{meetings_component.id}/meetings/#{meeting.id}"
+  end
+
+  context "when the meeting is in_person and has a google_maps_url" do
+    let!(:meeting) do
+      create(:meeting, :published, :in_person, component: meetings_component, google_maps_url:)
+    end
+
+    before { visit meeting_show_path(meeting) }
+
+    it "renders the address as a clickable Google Maps link" do
+      expect(page).to have_css(".address__address a[href='#{google_maps_url}'][target='_blank']")
+    end
+  end
+
+  context "when the meeting is hybrid and has a google_maps_url" do
+    let!(:meeting) do
+      create(:meeting, :published, :hybrid, component: meetings_component, google_maps_url:)
+    end
+
+    before { visit meeting_show_path(meeting) }
+
+    it "renders the address as a clickable Google Maps link" do
+      expect(page).to have_css(".address__address a[href='#{google_maps_url}'][target='_blank']")
+    end
+  end
+
+  context "when the meeting is in_person but has no google_maps_url" do
+    let!(:meeting) do
+      create(:meeting, :published, :in_person, component: meetings_component, google_maps_url: nil)
+    end
+
+    before { visit meeting_show_path(meeting) }
+
+    it "renders the address as plain text without a link" do
+      expect(page).to have_css(".address__address")
+      expect(page).to have_no_css(".address__address a")
+    end
+  end
+end

--- a/spec/system/meeting_google_maps_url_show_spec.rb
+++ b/spec/system/meeting_google_maps_url_show_spec.rb
@@ -6,7 +6,7 @@ describe "Google Maps URL on meeting show page", type: :system do
   let!(:organization) { create(:organization) }
   let!(:participatory_process) { create(:participatory_process, :published, :with_steps, organization:) }
   let!(:meetings_component) { create(:meeting_component, :published, participatory_space: participatory_process) }
-  let(:google_maps_url) { "https://maps.google.com/maps?q=Test+Location" }
+  let(:google_maps_url) { "https://www.google.com/maps/place/Test+Location" }
 
   before { switch_to_host(organization.host) }
 


### PR DESCRIPTION
#### :tophat: What? Why?
Adds a `google_maps_url` field to in-person and hybrid meetings. The field is optional and only shown in the admin form when the meeting type is in-person or hybrid (hidden for online meetings). On the public meeting page, the address text becomes a clickable link to the provided Google Maps URL, opening in a new tab.

<img width="1426" height="934" alt="image" src="https://github.com/user-attachments/assets/2380fe67-23e6-485a-9f27-d4d124984a6d" />

<img width="1426" height="934" alt="image" src="https://github.com/user-attachments/assets/5f7c5f06-6a8d-4bde-8c8e-e06a465c19b7" />

Validation 
<img width="1255" height="225" alt="image" src="https://github.com/user-attachments/assets/b66c417a-0cbb-428d-bfc9-0991f0e86c28" />


#### :clipboard: Subtasks
- [X] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [X] Add tests
- [ ] Another subtask
