### PR TITLE
Validate reCAPTCHA before user registration

### DIFF
--- a/decidim-recaptcha/Gemfile
+++ b/decidim-recaptcha/Gemfile
@@ -10,7 +10,7 @@ RECAPTCHA_DECIDIM_VERSION = { git: "https://github.com/CodiTramuntana/decidim", 
 
 gem "decidim", RECAPTCHA_DECIDIM_VERSION
 
-gem "recaptcha"
+gem "recaptcha", "~> 5.21.2"
 
 gem "stringio", ">= 3.1.7"
 

--- a/decidim-recaptcha/Gemfile.lock
+++ b/decidim-recaptcha/Gemfile.lock
@@ -643,7 +643,7 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
       ffi (~> 1.0)
-    recaptcha (5.21.1)
+    recaptcha (5.21.2)
     redcarpet (3.6.1)
     redis (4.8.1)
     regexp_parser (2.11.3)
@@ -826,7 +826,7 @@ DEPENDENCIES
   decidim-recaptcha!
   faker
   letter_opener_web
-  recaptcha
+  recaptcha (~> 5.21.2)
   stringio (>= 3.1.7)
 
 RUBY VERSION

--- a/decidim-recaptcha/app/decorators/decidim/commands/create_registration_decorator.rb
+++ b/decidim-recaptcha/app/decorators/decidim/commands/create_registration_decorator.rb
@@ -13,15 +13,10 @@ module Decidim::Commands::CreateRegistrationDecorator
         end
 
         # Recaptcha
-        original_create_user
-        recaptcha_valid = verify_recaptcha(model: @user, action: "registration", minimum_score: 0.9)
+        recaptcha_valid = verify_recaptcha(model: @form, action: "registration", minimum_score: 0.9)
 
         if recaptcha_valid
-          if @user.save
-            broadcast(:ok, @user)
-          else
-            broadcast(:invalid)
-          end
+          original_create_user ? broadcast(:ok, @user) : broadcast(:invalid)
         else
           @form.errors.add(:recaptcha, t("recaptcha.errors.recaptcha_unreachable"))
           broadcast(:invalid)

--- a/decidim-recaptcha/app/decorators/decidim/commands/create_registration_decorator.rb
+++ b/decidim-recaptcha/app/decorators/decidim/commands/create_registration_decorator.rb
@@ -18,7 +18,7 @@ module Decidim::Commands::CreateRegistrationDecorator
         if recaptcha_valid
           original_create_user ? broadcast(:ok, @user) : broadcast(:invalid)
         else
-          @form.errors.add(:recaptcha, t("recaptcha.errors.recaptcha_unreachable"))
+          @form.errors.add(:recaptcha, I18n.t("recaptcha.errors.recaptcha_unreachable"))
           broadcast(:invalid)
         end
         # Recaptcha

--- a/decidim-recaptcha/spec/commands/decidim/create_registration_spec.rb
+++ b/decidim-recaptcha/spec/commands/decidim/create_registration_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  describe CreateRegistration do
+    describe "call" do
+      let(:organization) { create(:organization) }
+      let(:name) { "Username" }
+      let(:email) { "user@example.org" }
+      let(:password) { "Y1fERVzL2F" }
+      let(:tos_agreement) { "1" }
+      let(:newsletter) { "1" }
+      let(:current_locale) { "es" }
+
+      let(:form_params) do
+        {
+          "user" => {
+            "name" => name,
+            "email" => email,
+            "password" => password,
+            "tos_agreement" => tos_agreement,
+            "newsletter_at" => newsletter
+          }
+        }
+      end
+      let(:form) do
+        RegistrationForm.from_params(
+          form_params,
+          current_locale:
+        ).with_context(
+          current_organization: organization
+        )
+      end
+      let(:command) { described_class.new(form) }
+
+      context "when recaptcha passes" do
+        before do
+          allow(command).to receive(:verify_recaptcha).and_return(true)
+        end
+
+        it "broadcasts ok" do
+          expect { command.call }.to broadcast(:ok)
+        end
+
+        it "creates a new user" do
+          expect { command.call }.to change(User, :count).by(1)
+        end
+      end
+
+      context "when recaptcha fails" do
+        before do
+          allow(command).to receive(:verify_recaptcha).and_return(false)
+        end
+
+        it "broadcasts invalid" do
+          expect { command.call }.to broadcast(:invalid)
+        end
+
+        it "does not create a user" do
+          expect { command.call }.not_to change(User, :count)
+        end
+
+        it "adds a recaptcha error to the form" do
+          command.call
+          expect(form.errors[:recaptcha]).to be_present
+        end
+      end
+    end
+  end
+end

--- a/decidim-recaptcha/spec/system/registration_spec.rb
+++ b/decidim-recaptcha/spec/system/registration_spec.rb
@@ -28,19 +28,42 @@ describe "Registration", type: :system do
 
   describe "when signing up" do
     context "with v3 recaptcha" do
-      it "renders input" do
+      it "renders the hidden recaptcha input" do
         expect(page).to have_css("#g-recaptcha-response-data-registration", visible: :hidden)
       end
     end
 
-    it "signing up successfully" do
-      fill_registration_form
-      page.check("registration_user_tos_agreement")
-      page.check("registration_user_newsletter")
-      within "form.new_user" do
-        find("*[type=submit]").click
+    context "when recaptcha passes" do
+      before do
+        allow_any_instance_of(Decidim::CreateRegistration).to receive(:verify_recaptcha).and_return(true)
       end
-      expect(page).to have_content("A message with a confirmation link has been sent to your email address.")
+
+      it "signs up successfully" do
+        fill_registration_form
+        page.check("registration_user_tos_agreement")
+        page.check("registration_user_newsletter")
+        within "form.new_user" do
+          find("*[type=submit]").click
+        end
+        expect(page).to have_content("A message with a confirmation link has been sent to your email address.")
+      end
+    end
+
+    context "when recaptcha fails" do
+      before do
+        allow_any_instance_of(Decidim::CreateRegistration).to receive(:verify_recaptcha).and_return(false)
+      end
+
+      it "does not sign up the user and shows an error" do
+        fill_registration_form
+        page.check("registration_user_tos_agreement")
+        page.check("registration_user_newsletter")
+        within "form.new_user" do
+          find("*[type=submit]").click
+        end
+        expect(page).to have_no_content("A message with a confirmation link has been sent to your email address.")
+        expect(Decidim::User.where(email: "nikola.tesla@example.org")).not_to exist
+      end
     end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
The reCaptcha was validated after the user was created, so if it failed it returned an error saying that the user could not be registered and the confirmation email was sent.

This PR first establishes the reCaptcha validation and then creates the user

