### PR TITLE
Set robots.txt to custom sitemap.xml location and format

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -15,7 +15,7 @@ Allow: /pages/
 Allow: /*.pdf$
 Allow: /*.js$
 Allow: /*.css$
-Sitemap: https://participa.gencat.cat/sitemap.xml
+Sitemap: https://participa.gencat.cat/sitemaps/sitemap.xml.gz
 
 User-agent: bingbot
 Allow: /


### PR DESCRIPTION
#### :tophat: What? Why?
First `robots.txt` was deployed, and now we're going to deploy the generation of the sitemap.xml hierarchy.
This PR sets the correct url for the sitemap in `robots.txt`.
