### PR TITLE
Fix uri version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,7 @@ gem "decidim-top_comments", path: "decidim-top_comments"
 
 gem "soda-ruby", require: false
 gem "stringio", "~> 3.1.7"
-gem "uri", "~> 1.0.4"
+gem "uri", "~> 1.1.1"
 
 gem "puma"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -904,7 +904,7 @@ GEM
     uber (0.1.0)
     unicode-display_width (2.6.0)
     uniform_notifier (1.18.0)
-    uri (1.0.4)
+    uri (1.1.1)
     valid_email2 (4.0.6)
       activemodel (>= 3.2)
       mail (~> 2.5)
@@ -995,7 +995,7 @@ DEPENDENCIES
   sitemap_generator (~> 7.0)
   soda-ruby
   stringio (~> 3.1.7)
-  uri (~> 1.0.4)
+  uri (~> 1.1.1)
   web-console
   whenever
   wicked_pdf (~> 2.8.2)


### PR DESCRIPTION
#### :tophat: What? Why?
URI version 1.1.1 was required, and the Gemfile was version 1.0.4

The URI version has been updated to 1.1.1

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)
![Description](URL)
